### PR TITLE
Fix for OnGather

### DIFF
--- a/RustExperimental.opj
+++ b/RustExperimental.opj
@@ -839,7 +839,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 54,
+            "InjectionIndex": 55,
             "ReturnBehaviour": 0,
             "ArgumentBehaviour": 4,
             "ArgumentString": "this,a0,l3",


### PR DESCRIPTION
Injection Index 54 throws the hook into the item null check which causes the hook to not trigger, the Injection Index 55 moves it to the check where the item is not null and causes the hook to trigger correctly.
