### PR TITLE
Fixes #34 Fixes #35

### DIFF
--- a/OxidePatcher/Hooks/Hook.cs
+++ b/OxidePatcher/Hooks/Hook.cs
@@ -166,7 +166,7 @@ namespace OxidePatcher.Hooks
         /// </summary>
         /// <param name="targetmethod"></param>
         /// <param name="oxidemodule"></param>
-        public abstract void ApplyPatch(MethodDefinition original, ILWeaver weaver, AssemblyDefinition oxidemodule);
+        public abstract bool ApplyPatch(MethodDefinition original, ILWeaver weaver, AssemblyDefinition oxidemodule, bool console);
 
         /// <summary>
         /// Creates the settings view control for this hook

--- a/OxidePatcher/Hooks/InitOxide.cs
+++ b/OxidePatcher/Hooks/InitOxide.cs
@@ -16,7 +16,7 @@ namespace OxidePatcher.Hooks
     public class InitOxide : Hook
     {
 
-        public override void ApplyPatch(MethodDefinition original, ILWeaver weaver, AssemblyDefinition oxideassembly)
+        public override bool ApplyPatch(MethodDefinition original, ILWeaver weaver, AssemblyDefinition oxideassembly, bool console)
         {
             MethodDefinition initoxidemethod = oxideassembly.MainModule.Types
                 .Single((t) => t.FullName == "Oxide.Core.Interface")
@@ -24,6 +24,7 @@ namespace OxidePatcher.Hooks
 
             weaver.Pointer = 0;
             weaver.Add(Instruction.Create(OpCodes.Call, weaver.Module.Import(initoxidemethod)));
+            return true;
         }
 
         public override Views.HookSettingsControl CreateSettingsView()

--- a/OxidePatcher/PatcherForm.cs
+++ b/OxidePatcher/PatcherForm.cs
@@ -198,6 +198,7 @@ namespace OxidePatcher
             PatchProcessForm patchprocess = new PatchProcessForm();
             patchprocess.PatchProject = CurrentProject;
             patchprocess.ShowDialog(this);
+            UpdateAllHooks();
         }
 
         #endregion
@@ -906,6 +907,16 @@ namespace OxidePatcher
                 if (tabpage.Tag is HookViewControl && (tabpage.Tag as HookViewControl).Hook == hook)
                 {
                     tabpage.Text = hook.Name;
+                    if (hook.Flagged)
+                    {
+                        (tabpage.Tag as HookViewControl).UnflagButton.Enabled = true;
+                        (tabpage.Tag as HookViewControl).FlagButton.Enabled = false;
+                    }
+                    else
+                    {
+                        (tabpage.Tag as HookViewControl).UnflagButton.Enabled = false;
+                        (tabpage.Tag as HookViewControl).FlagButton.Enabled = true;
+                    }
                 }
             }
 
@@ -940,6 +951,17 @@ namespace OxidePatcher
 
 
                     break;
+                }
+            }
+        }
+
+        public void UpdateAllHooks()
+        {
+            if (CurrentProject != null)
+            {
+                foreach (var hook in CurrentProject.Manifests.SelectMany((m) => m.Hooks))
+                {
+                    UpdateHook(hook);
                 }
             }
         }

--- a/OxidePatcher/Patching/Patcher.cs
+++ b/OxidePatcher/Patching/Patcher.cs
@@ -107,17 +107,42 @@ namespace OxidePatcher.Patching
                         try
                         {
                             // Apply
-                            hook.ApplyPatch(method, weaver, oxideassembly);
+                            bool patchApplied = hook.ApplyPatch(method, weaver, oxideassembly, console);
+                            if (patchApplied)
+                            {
                             weaver.Apply(method.Body);
+                            }
+                            else
+                            {
+                                if (console)
+                                {
+                                    Console.WriteLine(string.Format("The injection index specified for {0} is invalid!", hook.Name));
+                                }
+                                hook.Flagged = true;
+                            }
 
                             // Log
                             if (console)
                             {
+                                if (patchApplied)
+                                {
                                 Console.WriteLine(string.Format("Applied hook {0} to {1}::{2}", hook.Name, hook.TypeName, hook.Signature.Name));
                             }
                             else
                             {
+                                    Console.WriteLine(string.Format("Failed to apply hook {0}", hook.Name));
+                                }
+                            }
+                            else
+                            {
+                                if (patchApplied)
+                                {
                                 Log("Applied hook {0} to {1}::{2}", hook.Name, hook.TypeName, hook.Signature.Name);
+                            }
+                                else
+                                {
+                                    Log("Failed to apply hook {0}", hook.Name);
+                                }
                             }
                         }
                         catch (Exception ex)

--- a/OxidePatcher/Views/HookViewControl.cs
+++ b/OxidePatcher/Views/HookViewControl.cs
@@ -27,6 +27,10 @@ namespace OxidePatcher.Views
         /// </summary>
         public PatcherForm MainForm { get; set; }
 
+        public Button FlagButton { get; set; }
+
+        public Button UnflagButton { get; set; }
+
         private List<Type> hooktypes;
 
         private TextEditorControl msilbefore, msilafter;
@@ -38,6 +42,8 @@ namespace OxidePatcher.Views
         public HookViewControl()
         {
             InitializeComponent();
+            this.FlagButton = flagbutton;
+            this.UnflagButton = unflagbutton;
         }
 
         protected override void OnLoad(EventArgs e)
@@ -130,7 +136,7 @@ namespace OxidePatcher.Views
             msilbefore.Text = weaver.ToString();
             beforetab.Controls.Add(msilbefore);
 
-            Hook.ApplyPatch(methoddef, weaver, MainForm.OxideAssembly);
+            Hook.ApplyPatch(methoddef, weaver, MainForm.OxideAssembly, false);
 
             msilafter = new TextEditorControl();
             msilafter.Dock = DockStyle.Fill;
@@ -226,7 +232,7 @@ namespace OxidePatcher.Views
                 weaver.Module = methoddef.Module;
 
                 msilbefore.Text = weaver.ToString();
-                Hook.ApplyPatch(methoddef, weaver, MainForm.OxideAssembly);
+                Hook.ApplyPatch(methoddef, weaver, MainForm.OxideAssembly, false);
                 msilafter.Text = weaver.ToString();
             }
 


### PR DESCRIPTION
ApplyPatch method now accepts boolean to indicate if console is used or not;
If patch is attempted with invalid index, hook is flagged and patch of method fails;
Open tabs are now updated to reflect hook flagged/unflagged status changes;
Error Dialog now shown when Index is Out Of Range rather than unhandled exception dialog;
