### PR TITLE
Added InjectionIndex for InitOxide

### DIFF
--- a/OxidePatcher/Hooks/InitOxide.cs
+++ b/OxidePatcher/Hooks/InitOxide.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 
 using OxidePatcher.Patching;
+using OxidePatcher.Views;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -15,6 +16,10 @@ namespace OxidePatcher.Hooks
     [HookType("Initialise Oxide")]
     public class InitOxide : Hook
     {
+        /// <summary>
+        /// Gets or sets the instruction index to inject the hook call at
+        /// </summary>
+        public int InjectionIndex { get; set; }
 
         public override bool ApplyPatch(MethodDefinition original, ILWeaver weaver, AssemblyDefinition oxideassembly, bool console)
         {
@@ -22,14 +27,47 @@ namespace OxidePatcher.Hooks
                 .Single((t) => t.FullName == "Oxide.Core.Interface")
                 .Methods.Single((m) => m.IsStatic && m.Name == "Initialise");
 
-            weaver.Pointer = 0;
-            weaver.Add(Instruction.Create(OpCodes.Call, weaver.Module.Import(initoxidemethod)));
+            // Start injecting where requested
+            weaver.Pointer = InjectionIndex;
+
+            // Get the existing instruction we're going to inject behind
+            Instruction existing;
+            try
+            {
+                existing = weaver.Instructions[weaver.Pointer];
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                if (console == false)
+                {
+                    MessageBox.Show(string.Format("The injection index specified for {0} is invalid!", this.Name), "Invalid Index", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+                return false;
+            }
+
+            // Load the hook name
+            Instruction firstinjected = weaver.Add(Instruction.Create(OpCodes.Call, weaver.Module.Import(initoxidemethod)));
+
+            // Find all instructions which pointed to the existing and redirect them
+            for (int i = 0; i < weaver.Instructions.Count; i++)
+            {
+                Instruction ins = weaver.Instructions[i];
+                if (ins.Operand != null && ins.Operand.Equals(existing))
+                {
+                    // Check if the instruction lies within our injection range
+                    // If it does, it's an instruction we just injected so we don't want to edit it
+                    if (i < InjectionIndex || i > weaver.Pointer)
+                        ins.Operand = firstinjected;
+                }
+            }
             return true;
         }
 
         public override Views.HookSettingsControl CreateSettingsView()
         {
-            return null;
+            InitOxideHookSettingsControl control = new InitOxideHookSettingsControl();
+            control.Hook = this;
+            return control;
         }
     }
 }

--- a/OxidePatcher/Oxide.Patcher.csproj
+++ b/OxidePatcher/Oxide.Patcher.csproj
@@ -123,6 +123,12 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Icons.resx</DependentUpon>
     </Compile>
+    <Compile Include="Views\InitOxideHookSettingsControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Views\InitOxideHookSettingsControl.Designer.cs">
+      <DependentUpon>InitOxideHookSettingsControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="Views\SimpleHookSettingsControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -163,6 +169,9 @@
     <EmbeddedResource Include="Resources\Icons.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Icons.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Views\InitOxideHookSettingsControl.resx">
+      <DependentUpon>InitOxideHookSettingsControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\SimpleHookSettingsControl.resx">
       <DependentUpon>SimpleHookSettingsControl.cs</DependentUpon>

--- a/OxidePatcher/Views/InitOxideHookSettingsControl.Designer.cs
+++ b/OxidePatcher/Views/InitOxideHookSettingsControl.Designer.cs
@@ -1,0 +1,96 @@
+﻿namespace OxidePatcher.Views
+{
+	partial class InitOxideHookSettingsControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.label1 = new System.Windows.Forms.Label();
+			this.injectionindex = new System.Windows.Forms.NumericUpDown();
+			this.tableLayoutPanel1.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.injectionindex)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// tableLayoutPanel1
+			// 
+			this.tableLayoutPanel1.Anchor = System.Windows.Forms.AnchorStyles.Top;
+			this.tableLayoutPanel1.ColumnCount = 2;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 120F));
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+			this.tableLayoutPanel1.Controls.Add(this.injectionindex, 1, 0);
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(35, 3);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 1;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25.06266F));
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(344, 26);
+			this.tableLayoutPanel1.TabIndex = 0;
+			// 
+			// label1
+			// 
+			this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.label1.Location = new System.Drawing.Point(3, 0);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(114, 26);
+			this.label1.TabIndex = 0;
+			this.label1.Text = "Injection Index:";
+			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// injectionindex
+			// 
+			this.injectionindex.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.injectionindex.Location = new System.Drawing.Point(123, 3);
+			this.injectionindex.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+			this.injectionindex.Name = "injectionindex";
+			this.injectionindex.Size = new System.Drawing.Size(218, 20);
+			this.injectionindex.TabIndex = 6;
+			this.injectionindex.ValueChanged += new System.EventHandler(this.injectionindex_ValueChanged);
+			// 
+			// InitOxideHookSettingsControl
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.tableLayoutPanel1);
+			this.Name = "InitOxideHookSettingsControl";
+			this.Size = new System.Drawing.Size(415, 198);
+			this.tableLayoutPanel1.ResumeLayout(false);
+			((System.ComponentModel.ISupportInitialize)(this.injectionindex)).EndInit();
+			this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.NumericUpDown injectionindex;
+    }
+}

--- a/OxidePatcher/Views/InitOxideHookSettingsControl.cs
+++ b/OxidePatcher/Views/InitOxideHookSettingsControl.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using OxidePatcher.Hooks;
+
+namespace OxidePatcher.Views
+{
+    public partial class InitOxideHookSettingsControl : HookSettingsControl
+    {
+        private bool ignorechanges;
+
+        public InitOxideHookSettingsControl()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            InitOxide hook = Hook as InitOxide;
+
+            ignorechanges = true;
+            injectionindex.Value = hook.InjectionIndex;
+            ignorechanges = false;
+        }
+
+        private void injectionindex_ValueChanged(object sender, EventArgs e)
+        {
+            if (ignorechanges) return;
+
+            InitOxide hook = Hook as InitOxide;
+            hook.InjectionIndex = (int)injectionindex.Value;
+            NotifyChanges();
+        }
+    }
+}

--- a/OxidePatcher/Views/InitOxideHookSettingsControl.resx
+++ b/OxidePatcher/Views/InitOxideHookSettingsControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
This allows to move the Initialisation Hook to a better place, in case for Rust: after the ErrorHandler is installed.
That makes the server crash less (in case of an error that happens during initialisation) as errors are being catched and therefore help with debugging.

There might be other use cases that are more important when used with other games, I couldn't judge that though...
