### PR TITLE
Simplified patch logging logic

### DIFF
--- a/OxidePatcher/PatchProcessForm.cs
+++ b/OxidePatcher/PatchProcessForm.cs
@@ -90,7 +90,7 @@ namespace OxidePatcher
             {
                 Patcher patcher = new Patcher(PatchProject);
                 patcher.OnLogMessage += (msg) => WorkerWriteLog(msg);
-                patcher.Patch(false);
+                patcher.Patch();
             }
             catch (Exception ex)
             {

--- a/OxidePatcher/Program.cs
+++ b/OxidePatcher/Program.cs
@@ -158,8 +158,8 @@ namespace OxidePatcher
                 }
                 else
                 {
-                    Patcher patcher = new Patcher(PatchProject);
-                    patcher.Patch(true);
+                    Patcher patcher = new Patcher(PatchProject, true);
+                    patcher.Patch();
                     Console.WriteLine("Press Enter to continue...");
                 }
             }


### PR DESCRIPTION
Instead of fragmenting the logging code more, let's unify it instead.

This only solves the console part. Window logging is still spread troughout the code...
