### PR TITLE
Patcher fixes and improvements

### DIFF
--- a/src/Hooks/InitOxide.cs
+++ b/src/Hooks/InitOxide.cs
@@ -26,6 +26,7 @@ namespace Oxide.Patcher.Hooks
 
             // Start injecting where requested
             weaver.Pointer = InjectionIndex;
+            weaver.OriginalPointer = InjectionIndex;
 
             // Get the existing instruction we're going to inject behind
             Instruction existing;

--- a/src/Hooks/Modify.cs
+++ b/src/Hooks/Modify.cs
@@ -68,6 +68,7 @@ namespace Oxide.Patcher.Hooks
             }
             // Start injecting where requested
             weaver.Pointer = InjectionIndex;
+            weaver.OriginalPointer = InjectionIndex;
 
             if (!weaver.RemoveAfter(RemoveCount))
             {

--- a/src/PatchProcessForm.cs
+++ b/src/PatchProcessForm.cs
@@ -71,8 +71,11 @@ namespace Oxide.Patcher
                 }
             }
 
-            progressbar.Value++;
-            progressbar.Refresh();
+            if (progressbar.Maximum != progressbar.Value)
+            {
+                progressbar.Value++;
+                progressbar.Refresh();
+            }
 
             if (message.Contains(Environment.NewLine))
             {

--- a/src/Patching/ILWeaver.cs
+++ b/src/Patching/ILWeaver.cs
@@ -182,6 +182,7 @@ namespace Oxide.Patcher.Patching
             Instructions.Insert(Pointer, instruction);
             UpdateInstructions();
             AdjustBranches();
+            UpdateExceptionHandlers();
             Pointer++;
             return instruction;
         }
@@ -197,6 +198,7 @@ namespace Oxide.Patcher.Patching
             Instructions.Insert(position+1, Instruction);
             UpdateInstructions();
             AdjustBranches();
+            UpdateExceptionHandlers();
             Pointer++;
             return Instruction;
         }
@@ -317,6 +319,22 @@ namespace Oxide.Patcher.Patching
             }
             if(needsUpdate)
                 UpdateInstructions();
+        }
+
+        private void UpdateExceptionHandlers()
+        {
+            if (Pointer == 0 || ExceptionHandlers.Count == 0 || Instructions[Pointer - 1].OpCode != OpCodes.Endfinally)
+                return;
+            var oldHandlerEnd = Instructions[Pointer+1];
+            var newHandlerEnd = Instructions[Pointer];
+            for (var i = 0; i < ExceptionHandlers.Count; i++)
+            {
+                var handler = ExceptionHandlers[i];
+                if (handler.HandlerStart == null || handler.HandlerEnd != oldHandlerEnd)
+                    continue;
+                handler.HandlerEnd = newHandlerEnd;
+                break;
+            }
         }
 
         /// <summary>

--- a/src/Patching/ILWeaver.cs
+++ b/src/Patching/ILWeaver.cs
@@ -46,9 +46,19 @@ namespace Oxide.Patcher.Patching
         public IList<ExceptionHandler> ExceptionHandlers { get; }
 
         /// <summary>
+        /// Gets the created local variables for data on the stack (instruction index : variable id)
+        /// </summary>
+        public Dictionary<int, int> IntroducedLocals { get; }
+
+        /// <summary>
         /// Gets or sets the current instruction pointer
         /// </summary>
         public int Pointer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the original instruction pointer (initial injection index)
+        /// </summary>
+        public int OriginalPointer { get; set; }
 
         /// <summary>
         /// Gets or sets the module to which this weaver belongs
@@ -68,6 +78,7 @@ namespace Oxide.Patcher.Patching
             Instructions = new List<Instruction>();
             Variables = new List<VariableDefinition>();
             ExceptionHandlers = new List<ExceptionHandler>();
+            IntroducedLocals = new Dictionary<int, int>();
         }
 
         /// <summary>
@@ -141,9 +152,11 @@ namespace Oxide.Patcher.Patching
 
                 ExceptionHandlers.Add(newexhandler);
             }
+            IntroducedLocals = new Dictionary<int, int>();
             UpdateInstructions();
             Variables = new List<VariableDefinition>(body.Variables);
             Pointer = Instructions.Count - 1;
+            OriginalPointer = Pointer;
         }
 
         /// <summary>
@@ -156,6 +169,7 @@ namespace Oxide.Patcher.Patching
             Instructions = new List<Instruction>(instructions);
             Variables = new List<VariableDefinition>(variables);
             Pointer = Instructions.Count - 1;
+            OriginalPointer = Pointer;
         }
 
         /// <summary>
@@ -170,6 +184,21 @@ namespace Oxide.Patcher.Patching
             AdjustBranches();
             Pointer++;
             return instruction;
+        }
+
+        /// <summary>
+        /// Adds an instruction after specified position
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="instruction"></param>
+        /// <returns></returns>
+        public Instruction AddAfter(int position, Instruction Instruction)
+        {
+            Instructions.Insert(position+1, Instruction);
+            UpdateInstructions();
+            AdjustBranches();
+            Pointer++;
+            return Instruction;
         }
 
         /// <summary>

--- a/src/Patching/ILWeaver.cs
+++ b/src/Patching/ILWeaver.cs
@@ -268,6 +268,7 @@ namespace Oxide.Patcher.Patching
 
         private void AdjustBranches()
         {
+            var needsUpdate = false;
             for (var i = 0; i < Instructions.Count; i++)
             {
                 var ins = Instructions[i];
@@ -279,9 +280,14 @@ namespace Oxide.Patcher.Patching
                         ? operand.Offset - ins.Offset <= 129
                         : ins.Offset - operand.Offset <= 126;
                     if (!offsetTest)
+                    {
                         ins.OpCode = LongSubstituteOf(ins.OpCode);
+                        needsUpdate = true;
+                    }
                 }
             }
+            if(needsUpdate)
+                UpdateInstructions();
         }
 
         /// <summary>

--- a/src/Patching/ILWeaver.cs
+++ b/src/Patching/ILWeaver.cs
@@ -327,7 +327,10 @@ namespace Oxide.Patcher.Patching
         /// <returns></returns>
         public VariableDefinition AddVariable(TypeReference type, string name = "")
         {
-            VariableDefinition def = new VariableDefinition(type);
+            VariableDefinition def = new VariableDefinition(type)
+            {
+                Name = string.IsNullOrEmpty(name) ? $"OxideGen_{Variables.Count}" : name
+            };
             Variables.Add(def);
             return def;
         }


### PR DESCRIPTION
My PR consists of IL-Generation fixes and improvements which expands the patching abilities.

What's been fixed:
- Conditional dereferencing and boxing upon pushing data to the hook:
It was not correct to use a ByRef value types (`valuetype TypeName&`) for ldobj and box operation.
Not emitting ldobj/box operations anymore when accessing properties/fields (e.g `v10.Body`)
This also should solve NRE issues with Oxide, such as `GetHookMethod`.
- Fixed overflowing of branching instructions:
Replacing "near" instructions with "far" ones if operand would overflow due to an increase in code size.
This oversight was a source of errors like this:
`Invalid IL code in Type.Method(): IL_1234: brtrue.s  IL_ffffff12`
- Minor fix of the progress bar.
Don't allow increment if already reached maximum.

What's been added:
- New variable type `rXXX` for Argument String:
Acts just like typical  `v` or `l`. Except for one thing.
Instead of the variable index, the index of the callsite must be supplied (`call`/`callvirt`).
It fetches the returned data left by the method call from the stack, duplicates it and stores it in a new local variable.
- The created variables will receive a generated name (if it was not specified).
Can be useful for IL views.
- Added late instruction binding for Modify hook:
Now it's possible to use of not yet added (future) instructions as operands (e.g for branching).
- Made possible injecting hooks after finally blocks:
It was not possible before to inject code straight after `endfinally` instruction. 
Now the end of the finally block is handled correctly. Though it's not tested well enough.