### PR TITLE
Introduce local variables for Modify hooks

### DIFF
--- a/src/ModifyForm.cs
+++ b/src/ModifyForm.cs
@@ -116,6 +116,7 @@ namespace Oxide.Patcher
                 case Modify.OpType.Method:
                 case Modify.OpType.Generic:
                 case Modify.OpType.Type:
+                case Modify.OpType.VariableIndex:
                     textBox.Text = Instruction?.Operand?.ToString() ?? string.Empty;
                     control = textBox;
                     break;
@@ -240,6 +241,7 @@ namespace Oxide.Patcher
                 case Modify.OpType.Double:
                 case Modify.OpType.String:
                 case Modify.OpType.VerbatimString:
+                case Modify.OpType.VariableIndex:
                     Instruction.Operand = textBox.Text;
                     break;
 


### PR DESCRIPTION
This change automatically introduces local variables to the method definition when various stloc op codes are identified in the Modify hook instructions. Additional local variables are only introduced if they are at a higher index than the method definition currently supports.

This change also adds a VariableIndex operand type so that stloc and ldloc op codes can utilize local variable indexes above 3 that are being introduced by the Modify hook, since those don't currently appear in the patcher UI.