### PR TITLE
Recursively apply base hooks for the Instruction dialog

### DIFF
--- a/src/ModifyForm.cs
+++ b/src/ModifyForm.cs
@@ -128,7 +128,7 @@ namespace Oxide.Patcher
                     {
                         MethodDefinition methoddef = PatcherForm.MainForm.GetMethod(hook.AssemblyName, hook.TypeName, hook.Signature);
                         ILWeaver weaver = new ILWeaver(methoddef.Body) { Module = methoddef.Module };
-                        hook.BaseHook.ApplyPatch(methoddef, weaver, PatcherForm.MainForm.OxideAssembly);
+                        hook.PreparePatch(methoddef, weaver, PatcherForm.MainForm.OxideAssembly);
                         instructionset = weaver.Instructions;
                     }
                     for (int i = 0; i < instructionset.Count; i++)


### PR DESCRIPTION
This fixes a bug where selecting the Instruction op type for a modify hook only applies the base hook instead of looking further to see if that hook also has a base hook, and so on. In some cases, this bug produces an error dialog and prevents selecting instructions introduced by base hooks.