### PR TITLE
Allow argument string to contain new variables

### DIFF
--- a/src/Hooks/Simple.cs
+++ b/src/Hooks/Simple.cs
@@ -261,7 +261,7 @@ namespace Oxide.Patcher.Hooks
                     {
                         if (int.TryParse(arg.Substring(1), out int index))
                         {
-                            if (index < method.Body.Variables.Count)
+                            if (index < weaver.Variables.Count)
                             {
                                 VariableDefinition vdef = weaver.Variables[index];
 


### PR DESCRIPTION
This change allows the argument string field of a Simple hook to refer to new local variables introduced in base Modify hooks.

For example, `OnEngineStarted` was achieved with a Simple hook below.
```csharp
public void EngineStartup()
{
	object OxideGen_0 = Interface.CallHook("OnEngineStart", this, base.GetDriver());
	if (OxideGen_0 != null)
	{
		return;
	}
	if (this.Waterlogged())
	{
		return;
	}
	base.Invoke(new Action(this.EngineOn), 5f);
	base.SetFlag(global::BaseEntity.Flags.Reserved4, true, false, true);
	Interface.CallHook("OnEngineStarted ", this, OxideGen_0);
}
```