### PR TITLE
Fix insertion index for "insert before" button

### DIFF
--- a/src/ModifyForm.cs
+++ b/src/ModifyForm.cs
@@ -196,7 +196,7 @@ namespace Oxide.Patcher
                 return;
             }
 
-            Index = -1;
+            Index = 0;
             DialogResult = DialogResult.OK;
         }
 


### PR DESCRIPTION
This fixes an issue where inserting an instruction in a Modify hook using the "insert before" button will insert it one spot before the spot you would expect.