### PR TITLE
Fix static exposure determination for getter-only properties

### DIFF
--- a/src/Views/ModifierSettingsControl.cs
+++ b/src/Views/ModifierSettingsControl.cs
@@ -67,11 +67,11 @@ namespace Oxide.Patcher.Views
                     isPrivateSetter.Text += " setter";
                     isProtectedSetter.Text += " setter";
                     isInternalSetter.Text += " setter";
-                    isStatic.Checked = Modifier.TargetExposure.Length == 3;
+                    isStatic.Checked = PropertyDef.SetMethod.IsStatic;
                 }
                 else
                 {
-                    isStatic.Checked = Modifier.TargetExposure.Length == 2;
+                    isStatic.Checked = PropertyDef.GetMethod.IsStatic;
                 }
             }
             else


### PR DESCRIPTION
Steps to reproduce issue:
1. Open the patcher with Rust.opj
2. Select BaseEntity class
3. Select a non-static property such as isClient
4. Click "Edit Property Modifier"
5. Notice that the static box is already checked

Tested fix with:
- Member properties with only a getter
- Member properties with both a getter and setter
- Static properties with only a getter

I was unable to find any static properties with a setter to test with. Low blast radius if there is an issue with that due to the scarcity as well as the fact that the bug only happens when editing modifiers for the first time for a property.