### PR TITLE
Fix static access modifier presentation for properties

### DIFF
--- a/src/Modifiers/Modifier.cs
+++ b/src/Modifiers/Modifier.cs
@@ -257,6 +257,11 @@ namespace Oxide.Patcher.Modifiers
             MSILHash = string.Empty;
         }
 
+        public bool HasTargetExposure(Exposure exposure)
+        {
+            return TargetExposure?.Any(x => x == exposure) ?? false;
+        }
+
         protected void ShowMsg(string msg, string header, Patching.Patcher patcher)
         {
             if (patcher != null)

--- a/src/Views/ModifierSettingsControl.cs
+++ b/src/Views/ModifierSettingsControl.cs
@@ -67,16 +67,16 @@ namespace Oxide.Patcher.Views
                     isPrivateSetter.Text += " setter";
                     isProtectedSetter.Text += " setter";
                     isInternalSetter.Text += " setter";
-                    isStatic.Checked = PropertyDef.SetMethod.IsStatic;
+                    isStatic.Checked = Modifier.HasTargetExposure(Exposure.Static);
                 }
                 else
                 {
-                    isStatic.Checked = PropertyDef.GetMethod.IsStatic;
+                    isStatic.Checked = Modifier.HasTargetExposure(Exposure.Static);
                 }
             }
             else
             {
-                isStatic.Checked = Modifier.TargetExposure.Length == 2;
+                isStatic.Checked = Modifier.HasTargetExposure(Exposure.Static);
             }
 
             if (Modifier.Type == ModifierType.Type)


### PR DESCRIPTION
Fixes bug introduced in https://github.com/OxideMod/Oxide.Patcher/commit/c28fe7f36518be986c4715bc47f0e584e2980e51 where toggling a property to static or non-static would not be reflected the next time the modifier form was opened for that property. It would basically always override the previously set value with the value of the original signature.

Tested fix with:
- Member properties with only a getter
- Member properties with both a getter and setter
- Static properties with only a getter

Verified that the correct checkboxes are checked when opening the form for the first time. Also verified that making changes to which checkboxes are selected and reopening the form shows the same checkboxes selected.