### PR TITLE
Add field injection support

### DIFF
--- a/src/ModifyForm.cs
+++ b/src/ModifyForm.cs
@@ -271,7 +271,29 @@ namespace Oxide.Patcher
                         break;
                     }
                     FieldDefinition fieldField = fieldType.Fields.FirstOrDefault(f => f.Name.Equals(fieldData[2]));
-                    if (fieldField == null)
+                    bool resolved = fieldField != null;
+
+                    // Resolve injected fields
+                    if (!resolved)
+                    {
+                        foreach (Manifest manifest in PatcherForm.MainForm.CurrentProject.Manifests)
+                        {
+                            if (manifest.AssemblyName != fieldData[0] + ".dll") continue;
+                            foreach (Field field in manifest.Fields)
+                            {
+                                if (field.Flagged) continue;
+                                if (field.TypeName != fieldData[1]) continue;
+                                if (field.Name != fieldData[2]) continue;
+
+                                resolved = true;
+                                break;
+                            }
+
+                            break;
+                        }
+                    }
+
+                    if (!resolved)
                     {
                         error = $"Field '{fieldData[2]}' not found";
                         break;

--- a/src/Oxide.Patcher.csproj
+++ b/src/Oxide.Patcher.csproj
@@ -2,7 +2,7 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <AssemblyName>OxidePatcher</AssemblyName>
     <RootNamespace>Oxide.Patcher</RootNamespace>
     <Authors>Oxide and Contributors</Authors>


### PR DESCRIPTION
Added support for field injection by enabling the `ldfld` opcode to resolve references to injected fields.

### Notes
- The UI modify form has an added check to resolve injected fields. I intentionally left this as a simple check as the primary validation checks are already completed when modifying the injected field.
- Saving assemblies now works with two passes (re: saved twice). Saving the assembly twice can be avoided with an architectural change that caches all assemblies in memory before saving, however, the two passes is necessary to populate the injected targets without overcomplicating the codebase.