### PR TITLE
Adding hook returnType to docs.json file

### DIFF
--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -22,6 +22,7 @@ namespace Oxide.Patcher.Docs
         public string HookName { get; set; }
         public string HookDescription { get; set; }
         public Dictionary<string, string> HookParameters { get; set; }
+        public string ReturnType { get; set; }
         public ReturnBehavior ReturnBehavior { get; set; } = ReturnBehavior.Continue;
         public string TargetType { get; set; }
         public string Category { get; set; }
@@ -45,6 +46,7 @@ namespace Oxide.Patcher.Docs
                     Type = HookType.Simple;
                     ReturnBehavior = simpleHook.ReturnBehavior;
                     HookParameters = GetHookArguments(simpleHook, methodDef);
+                    ReturnType = GetReturnType(simpleHook, methodDef);
                     break;
 
                 case Modify modifyHook:
@@ -163,6 +165,42 @@ namespace Oxide.Patcher.Docs
             }
 
             return hookArguments;
+        }
+
+        private string GetReturnType(Simple hook, MethodDefinition method)
+        {
+            string returnType = "";
+            try
+            {
+                switch (hook?.ReturnBehavior)
+                {
+                    case ReturnBehavior.Continue:
+                        returnType = "void";
+                        break;
+
+                    case ReturnBehavior.ExitWhenNonNull:
+                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
+                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);
+                        break;
+
+                    case ReturnBehavior.ExitWhenValidType:
+                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
+                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);
+                        break;
+
+                    case ReturnBehavior.ModifyRefArg:
+                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
+                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);  
+                        break;
+
+                    case ReturnBehavior.UseArgumentString:
+                        string[] args = Utility.ParseArgumentString(hook.ArgumentString, out string returnValue);
+                        returnType = Utility.TransformType(GetArgStringType(returnValue, method, out string argName));
+                        break;
+                }                
+            } catch { returnType = "ERROR"; }
+
+            return returnType;
         }
 
         //Doesn't work if I use the Decompiler class so just do this for now

--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -22,7 +22,7 @@ namespace Oxide.Patcher.Docs
         public string HookName { get; set; }
         public string HookDescription { get; set; }
         public Dictionary<string, string> HookParameters { get; set; }
-        public string ReturnType { get; set; }
+        public string ReturnTypeOverwrite { get; set; }
         public ReturnBehavior ReturnBehavior { get; set; } = ReturnBehavior.Continue;
         public string TargetType { get; set; }
         public string Category { get; set; }
@@ -46,7 +46,7 @@ namespace Oxide.Patcher.Docs
                     Type = HookType.Simple;
                     ReturnBehavior = simpleHook.ReturnBehavior;
                     HookParameters = GetHookArguments(simpleHook, methodDef);
-                    ReturnType = GetReturnType(simpleHook, methodDef);
+                    ReturnTypeOverwrite = GetReturnType(simpleHook, methodDef);
                     break;
 
                 case Modify modifyHook:
@@ -169,38 +169,22 @@ namespace Oxide.Patcher.Docs
 
         private string GetReturnType(Simple hook, MethodDefinition method)
         {
-            string returnType = "";
-            try
+            switch (hook?.ReturnBehavior)
             {
-                switch (hook?.ReturnBehavior)
-                {
-                    case ReturnBehavior.Continue:
-                        returnType = "void";
-                        break;
+                case ReturnBehavior.Continue:
+                    return null;
 
-                    case ReturnBehavior.ExitWhenNonNull:
-                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
-                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);
-                        break;
+                case ReturnBehavior.ExitWhenNonNull:
+                case ReturnBehavior.ExitWhenValidType:
+                case ReturnBehavior.ModifyRefArg:
+                    return hook?.Signature.ReturnType == "System.Void" ? null : Utility.TransformType(hook?.Signature.ReturnType);
 
-                    case ReturnBehavior.ExitWhenValidType:
-                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
-                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);
-                        break;
+                case ReturnBehavior.UseArgumentString:
+                    Utility.ParseArgumentString(hook.ArgumentString, out string returnValue);
+                    return Utility.TransformType(GetArgStringType(returnValue, method, out string _));
+            }
 
-                    case ReturnBehavior.ModifyRefArg:
-                        if (hook?.Signature.ReturnType == "System.Void") returnType = "object";
-                        else returnType = Utility.TransformType(hook?.Signature.ReturnType);  
-                        break;
-
-                    case ReturnBehavior.UseArgumentString:
-                        string[] args = Utility.ParseArgumentString(hook.ArgumentString, out string returnValue);
-                        returnType = Utility.TransformType(GetArgStringType(returnValue, method, out string argName));
-                        break;
-                }                
-            } catch { returnType = "ERROR"; }
-
-            return returnType;
+            return null;
         }
 
         //Doesn't work if I use the Decompiler class so just do this for now


### PR DESCRIPTION
This PR affect Docs.json file generation only
Add the new ReturnType parameter for the Hook in Docs.json. This field is needed for the Oxide.Docs project to be able to add a valid return type to function example.