### PR TITLE
Minor improvements in the new project creation window

### DIFF
--- a/src/Forms/NewProjectForm.Designer.cs
+++ b/src/Forms/NewProjectForm.Designer.cs
@@ -110,6 +110,7 @@
             this.filenametextbox.Name = "filenametextbox";
             this.filenametextbox.Size = new System.Drawing.Size(314, 20);
             this.filenametextbox.TabIndex = 7;
+            this.filenametextbox.TextChanged += new System.EventHandler(this.filenametextbox_TextChanged);
             // 
             // directorylabel
             // 
@@ -141,6 +142,7 @@
             this.nametextbox.Size = new System.Drawing.Size(347, 20);
             this.nametextbox.TabIndex = 3;
             this.nametextbox.Text = "Untitled Oxide Project";
+            this.nametextbox.TextChanged += new System.EventHandler(this.nametextbox_TextChanged);
             // 
             // selectdirectorybutton
             // 
@@ -160,6 +162,7 @@
             this.directorytextbox.Name = "directorytextbox";
             this.directorytextbox.Size = new System.Drawing.Size(314, 20);
             this.directorytextbox.TabIndex = 5;
+            this.directorytextbox.TextChanged += new System.EventHandler(this.directorytextbox_TextChanged);
             // 
             // createbutton
             // 


### PR DESCRIPTION
## Changes

- Added a warning about missing libraries in the **target directory** when attempting to create a new project;
- Added toggle functionality for the **Create** button's availability based on the emptiness of all **TextBoxes**. Previously, it was possible to click the **Create** button with empty values, which caused the application to crash;
- Added forced addition of the **.opj** extension when clicking the **Create** button. Previously, it was possible to create projects without an extension;
- Removed the check for **nametextbox.TextLength == 0**, as the **Create** button will not be enabled if the name is empty, making the length check unnecessary.