### PR TITLE
Minor changes for improved usability

### DIFF
--- a/src/PatcherForm.Designer.cs
+++ b/src/PatcherForm.Designer.cs
@@ -96,96 +96,89 @@ namespace Oxide.Patcher
             this.hookmenu.SuspendLayout();
             this.modifiersMenu.SuspendLayout();
             this.SuspendLayout();
-
-            //
+            // 
             // mainmenu
-            //
-            this.mainmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.filemenu
-            });
+            // 
+            this.mainmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.filemenu});
             this.mainmenu.Location = new System.Drawing.Point(0, 0);
             this.mainmenu.Name = "mainmenu";
             this.mainmenu.Size = new System.Drawing.Size(1264, 24);
             this.mainmenu.TabIndex = 0;
             this.mainmenu.Text = "menuStrip1";
-
-            //
+            // 
             // filemenu
-            //
-            this.filemenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.newproject, this.openproject, this.toolStripSeparator1, this.recentprojects, this.toolStripSeparator2, this.exit
-            });
+            // 
+            this.filemenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.newproject,
+            this.openproject,
+            this.toolStripSeparator1,
+            this.recentprojects,
+            this.toolStripSeparator2,
+            this.exit});
             this.filemenu.Name = "filemenu";
             this.filemenu.Size = new System.Drawing.Size(37, 20);
             this.filemenu.Text = "File";
-
-            //
+            // 
             // newproject
-            //
+            // 
             this.newproject.Image = global::Oxide.Patcher.Properties.Resources.book_add;
             this.newproject.Name = "newproject";
             this.newproject.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.newproject.Size = new System.Drawing.Size(186, 22);
+            this.newproject.Size = new System.Drawing.Size(194, 22);
             this.newproject.Text = "New Project";
             this.newproject.Click += new System.EventHandler(this.newproject_Click);
-
-            //
+            // 
             // openproject
-            //
+            // 
             this.openproject.Image = global::Oxide.Patcher.Properties.Resources.book_go;
             this.openproject.Name = "openproject";
             this.openproject.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openproject.Size = new System.Drawing.Size(186, 22);
+            this.openproject.Size = new System.Drawing.Size(194, 22);
             this.openproject.Text = "Open Project";
             this.openproject.Click += new System.EventHandler(this.openproject_Click);
-
-            //
+            // 
             // toolStripSeparator1
-            //
+            // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(183, 6);
-
-            //
+            this.toolStripSeparator1.Size = new System.Drawing.Size(191, 6);
+            // 
             // recentprojects
-            //
+            // 
             this.recentprojects.Name = "recentprojects";
-            this.recentprojects.Size = new System.Drawing.Size(186, 22);
+            this.recentprojects.Size = new System.Drawing.Size(194, 22);
             this.recentprojects.Text = "Recent Projects";
-
-            //
+            // 
             // toolStripSeparator2
-            //
+            // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(183, 6);
-
-            //
+            this.toolStripSeparator2.Size = new System.Drawing.Size(191, 6);
+            // 
             // exit
-            //
+            // 
             this.exit.Image = global::Oxide.Patcher.Properties.Resources.door_in;
             this.exit.Name = "exit";
             this.exit.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this.exit.Size = new System.Drawing.Size(186, 22);
+            this.exit.Size = new System.Drawing.Size(194, 22);
             this.exit.Text = "Exit";
             this.exit.Click += new System.EventHandler(this.exit_Click);
-
-            //
+            // 
             // maintoolbar
-            //
-            this.maintoolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.newprojecttool, this.openprojecttool, this.generateDocsButton, this.toolStripSeparator3, this.patchtool
-            });
+            // 
+            this.maintoolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.newprojecttool,
+            this.openprojecttool,
+            this.generateDocsButton,
+            this.toolStripSeparator3,
+            this.patchtool});
             this.maintoolbar.Location = new System.Drawing.Point(0, 24);
             this.maintoolbar.Name = "maintoolbar";
             this.maintoolbar.Size = new System.Drawing.Size(1264, 25);
             this.maintoolbar.TabIndex = 1;
             this.maintoolbar.Text = "toolStrip1";
-
-            //
+            // 
             // newprojecttool
-            //
+            // 
             this.newprojecttool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.newprojecttool.Image = global::Oxide.Patcher.Properties.Resources.book_add;
             this.newprojecttool.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -193,10 +186,9 @@ namespace Oxide.Patcher
             this.newprojecttool.Size = new System.Drawing.Size(23, 22);
             this.newprojecttool.Text = "New Project";
             this.newprojecttool.Click += new System.EventHandler(this.newprojecttool_Click);
-
-            //
+            // 
             // openprojecttool
-            //
+            // 
             this.openprojecttool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.openprojecttool.Image = global::Oxide.Patcher.Properties.Resources.book_go;
             this.openprojecttool.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -204,10 +196,9 @@ namespace Oxide.Patcher
             this.openprojecttool.Size = new System.Drawing.Size(23, 22);
             this.openprojecttool.Text = "Open Project";
             this.openprojecttool.Click += new System.EventHandler(this.openprojecttool_Click);
-
-            //
+            // 
             // generateDocsButton
-            //
+            // 
             this.generateDocsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.generateDocsButton.Image = global::Oxide.Patcher.Resources.Icons.lightning;
             this.generateDocsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -215,16 +206,14 @@ namespace Oxide.Patcher
             this.generateDocsButton.Size = new System.Drawing.Size(23, 22);
             this.generateDocsButton.Text = "Generate Docs";
             this.generateDocsButton.Click += new System.EventHandler(this.generateDocsButton_Click);
-
-            //
+            // 
             // toolStripSeparator3
-            //
+            // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
-
-            //
+            // 
             // patchtool
-            //
+            // 
             this.patchtool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.patchtool.Enabled = false;
             this.patchtool.Image = global::Oxide.Patcher.Properties.Resources.wand;
@@ -233,49 +222,41 @@ namespace Oxide.Patcher
             this.patchtool.Size = new System.Drawing.Size(23, 22);
             this.patchtool.Text = "Patch";
             this.patchtool.Click += new System.EventHandler(this.patchtool_Click);
-
-            //
+            // 
             // mainstatusbar
-            //
-            this.mainstatusbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.statuslabel
-            });
+            // 
+            this.mainstatusbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.statuslabel});
             this.mainstatusbar.Location = new System.Drawing.Point(0, 659);
             this.mainstatusbar.Name = "mainstatusbar";
             this.mainstatusbar.Size = new System.Drawing.Size(1264, 22);
             this.mainstatusbar.TabIndex = 3;
             this.mainstatusbar.Text = "statusStrip1";
-
-            //
+            // 
             // statuslabel
-            //
+            // 
             this.statuslabel.Name = "statuslabel";
             this.statuslabel.Size = new System.Drawing.Size(0, 17);
-
-            //
+            // 
             // splitter
-            //
+            // 
             this.splitter.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitter.Location = new System.Drawing.Point(0, 49);
             this.splitter.Name = "splitter";
-
-            //
+            // 
             // splitter.Panel1
-            //
+            // 
             this.splitter.Panel1.Controls.Add(this.objectview);
-
-            //
+            // 
             // splitter.Panel2
-            //
+            // 
             this.splitter.Panel2.Controls.Add(this.tabview);
             this.splitter.Size = new System.Drawing.Size(1264, 610);
             this.splitter.SplitterDistance = 268;
             this.splitter.TabIndex = 4;
-
-            //
+            // 
             // objectview
-            //
+            // 
             this.objectview.AllowDrop = true;
             this.objectview.Dock = System.Windows.Forms.DockStyle.Fill;
             this.objectview.ImageIndex = 0;
@@ -294,10 +275,9 @@ namespace Oxide.Patcher
             this.objectview.DragOver += new System.Windows.Forms.DragEventHandler(this.objectview_DragOver);
             this.objectview.DragLeave += new System.EventHandler(this.objectview_DragLeave);
             this.objectview.MouseDown += new System.Windows.Forms.MouseEventHandler(this.objectview_MouseDown);
-
-            //
+            // 
             // imagelist
-            //
+            // 
             this.imagelist.ImageStream = ((System.Windows.Forms.ImageListStreamer)(resources.GetObject("imagelist.ImageStream")));
             this.imagelist.TransparentColor = System.Drawing.Color.Transparent;
             this.imagelist.Images.SetKeyName(0, "book_add.png");
@@ -325,10 +305,10 @@ namespace Oxide.Patcher
             this.imagelist.Images.SetKeyName(22, "error.png");
             this.imagelist.Images.SetKeyName(23, "script_lightning.png");
             this.imagelist.Images.SetKeyName(24, "folder_flagged.png");
-
-            //
+            // 
             // tabview
-            //
+            // 
+            this.tabview.AllowDrop = true;
             this.tabview.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabview.ItemSize = new System.Drawing.Size(110, 18);
             this.tabview.Location = new System.Drawing.Point(0, 0);
@@ -336,250 +316,223 @@ namespace Oxide.Patcher
             this.tabview.SelectedIndex = 0;
             this.tabview.Size = new System.Drawing.Size(992, 610);
             this.tabview.TabIndex = 0;
+            this.tabview.DragOver += new System.Windows.Forms.DragEventHandler(this.tabview_DragOver);
             this.tabview.MouseClick += new System.Windows.Forms.MouseEventHandler(this.tabview_MouseClick);
-
-            //
+            this.tabview.MouseDown += new System.Windows.Forms.MouseEventHandler(this.tabview_MouseDown);
+            this.tabview.MouseMove += new System.Windows.Forms.MouseEventHandler(this.tabview_MouseMove);
+            this.tabview.MouseUp += new System.Windows.Forms.MouseEventHandler(this.tabview_MouseUp);
+            // 
             // tabviewcontextmenu
-            //
-            this.tabviewcontextmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.closeTabToolStripMenuItem, this.closeOtherTabsMenuItem
-            });
+            // 
+            this.tabviewcontextmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.closeTabToolStripMenuItem,
+            this.closeOtherTabsMenuItem});
             this.tabviewcontextmenu.Name = "tabviewcontextmenu";
             this.tabviewcontextmenu.Size = new System.Drawing.Size(163, 48);
-
-            //
+            // 
             // closeTabToolStripMenuItem
-            //
+            // 
             this.closeTabToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.closeTabToolStripMenuItem.Name = "closeTabToolStripMenuItem";
             this.closeTabToolStripMenuItem.Size = new System.Drawing.Size(162, 22);
             this.closeTabToolStripMenuItem.Text = "Close Tab";
             this.closeTabToolStripMenuItem.Click += new System.EventHandler(this.closetab_Click);
-
-            //
+            // 
             // closeOtherTabsMenuItem
-            //
+            // 
             this.closeOtherTabsMenuItem.Name = "closeOtherTabsMenuItem";
             this.closeOtherTabsMenuItem.Size = new System.Drawing.Size(162, 22);
             this.closeOtherTabsMenuItem.Text = "Close Other Tabs";
             this.closeOtherTabsMenuItem.Click += new System.EventHandler(this.closeothertabs_Click);
-
-            //
+            // 
             // openprojectdialog
-            //
+            // 
             this.openprojectdialog.DefaultExt = "opj";
             this.openprojectdialog.Filter = "Oxide project|*.opj";
             this.openprojectdialog.Title = "Open Project";
-
-            //
+            // 
             // unloadedassemblymenu
-            //
-            this.unloadedassemblymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.addtoproject
-            });
+            // 
+            this.unloadedassemblymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.addtoproject});
             this.unloadedassemblymenu.Name = "unloadedassemblymenu";
             this.unloadedassemblymenu.Size = new System.Drawing.Size(151, 26);
             this.unloadedassemblymenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.unloadedassemblymenu_ItemClicked);
-
-            //
+            // 
             // addtoproject
-            //
+            // 
             this.addtoproject.Name = "addtoproject";
             this.addtoproject.Size = new System.Drawing.Size(150, 22);
             this.addtoproject.Text = "Add to Project";
-
-            //
+            // 
             // loadedassemblymenu
-            //
-            this.loadedassemblymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.removefromproject
-            });
+            // 
+            this.loadedassemblymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.removefromproject});
             this.loadedassemblymenu.Name = "unloadedassemblymenu";
             this.loadedassemblymenu.Size = new System.Drawing.Size(187, 26);
             this.loadedassemblymenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.loadedassemblymenu_ItemClicked);
-
-            //
+            // 
             // removefromproject
-            //
+            // 
             this.removefromproject.Name = "removefromproject";
             this.removefromproject.Size = new System.Drawing.Size(186, 22);
             this.removefromproject.Text = "Remove from Project";
-
-            //
+            // 
             // hooksmenu
-            //
-            this.hooksmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.FlagMenuItem, this.UnflagMenuItem, this.toolStripSeparator4, this.FlagAllItem, this.UnflagAllItem
-            });
+            // 
+            this.hooksmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.FlagMenuItem,
+            this.UnflagMenuItem,
+            this.toolStripSeparator4,
+            this.FlagAllItem,
+            this.UnflagAllItem});
             this.hooksmenu.Name = "hooksmenu";
             this.hooksmenu.Size = new System.Drawing.Size(127, 98);
-
-            //
+            // 
             // FlagMenuItem
-            //
+            // 
             this.FlagMenuItem.Name = "FlagMenuItem";
             this.FlagMenuItem.Size = new System.Drawing.Size(126, 22);
             this.FlagMenuItem.Text = "Flag";
             this.FlagMenuItem.Click += new System.EventHandler(this.flag_Click);
-
-            //
+            // 
             // UnflagMenuItem
-            //
+            // 
             this.UnflagMenuItem.Name = "UnflagMenuItem";
             this.UnflagMenuItem.Size = new System.Drawing.Size(126, 22);
             this.UnflagMenuItem.Text = "Unflag";
             this.UnflagMenuItem.Click += new System.EventHandler(this.unflag_Click);
-
-            //
+            // 
             // toolStripSeparator4
-            //
+            // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(123, 6);
-
-            //
+            // 
             // FlagAllItem
-            //
+            // 
             this.FlagAllItem.Name = "FlagAllItem";
             this.FlagAllItem.Size = new System.Drawing.Size(126, 22);
             this.FlagAllItem.Text = "Flag All";
             this.FlagAllItem.Click += new System.EventHandler(this.flagall_Click);
-
-            //
+            // 
             // UnflagAllItem
-            //
+            // 
             this.UnflagAllItem.Name = "UnflagAllItem";
             this.UnflagAllItem.Size = new System.Drawing.Size(126, 22);
             this.UnflagAllItem.Text = "Unflag All";
             this.UnflagAllItem.Click += new System.EventHandler(this.unflagall_Click);
-
-            //
+            // 
             // categorymenu
-            //
-            this.categorymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.toolStripMenuItem1, this.toolStripMenuItem3, this.toolStripSeparator5, this.FlagCategory, this.UnflagCategory
-            });
+            // 
+            this.categorymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem1,
+            this.toolStripMenuItem3,
+            this.toolStripSeparator5,
+            this.FlagCategory,
+            this.UnflagCategory});
             this.categorymenu.Name = "hooksmenu";
             this.categorymenu.Size = new System.Drawing.Size(127, 98);
-
-            //
+            // 
             // toolStripMenuItem1
-            //
+            // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
             this.toolStripMenuItem1.Size = new System.Drawing.Size(126, 22);
             this.toolStripMenuItem1.Text = "Rename";
             this.toolStripMenuItem1.Click += new System.EventHandler(this.renamecategory_Click);
-
-            //
+            // 
             // toolStripMenuItem3
-            //
+            // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
             this.toolStripMenuItem3.Size = new System.Drawing.Size(126, 22);
             this.toolStripMenuItem3.Text = "Remove";
             this.toolStripMenuItem3.Click += new System.EventHandler(this.removecategory_Click);
-
-            //
+            // 
             // toolStripSeparator5
-            //
+            // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(123, 6);
-
-            //
+            // 
             // FlagCategory
-            //
+            // 
             this.FlagCategory.Name = "FlagCategory";
             this.FlagCategory.Size = new System.Drawing.Size(126, 22);
             this.FlagCategory.Text = "Flag All";
             this.FlagCategory.Click += new System.EventHandler(this.FlagCategory_Click);
-
-            //
+            // 
             // UnflagCategory
-            //
+            // 
             this.UnflagCategory.Name = "UnflagCategory";
             this.UnflagCategory.Size = new System.Drawing.Size(126, 22);
             this.UnflagCategory.Text = "Unflag All";
             this.UnflagCategory.Click += new System.EventHandler(this.UnflagCategory_Click);
-
-            //
+            // 
             // hookmenu
-            //
-            this.hookmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.toolStripMenuItem4, this.toolStripSeparator6, this.toolStripMenuItem5, this.toolStripMenuItem6
-            });
+            // 
+            this.hookmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem4,
+            this.toolStripSeparator6,
+            this.toolStripMenuItem5,
+            this.toolStripMenuItem6});
             this.hookmenu.Name = "hooksmenu";
             this.hookmenu.Size = new System.Drawing.Size(148, 76);
-
-            //
+            // 
             // toolStripMenuItem4
-            //
+            // 
             this.toolStripMenuItem4.Name = "toolStripMenuItem4";
             this.toolStripMenuItem4.Size = new System.Drawing.Size(147, 22);
             this.toolStripMenuItem4.Text = "Add Category";
             this.toolStripMenuItem4.Click += new System.EventHandler(this.addcategory_Click);
-
-            //
+            // 
             // toolStripSeparator6
-            //
+            // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
             this.toolStripSeparator6.Size = new System.Drawing.Size(144, 6);
-
-            //
+            // 
             // toolStripMenuItem5
-            //
+            // 
             this.toolStripMenuItem5.Name = "toolStripMenuItem5";
             this.toolStripMenuItem5.Size = new System.Drawing.Size(147, 22);
             this.toolStripMenuItem5.Text = "Flag All";
             this.toolStripMenuItem5.Click += new System.EventHandler(this.flagall_Click);
-
-            //
+            // 
             // toolStripMenuItem6
-            //
+            // 
             this.toolStripMenuItem6.Name = "toolStripMenuItem6";
             this.toolStripMenuItem6.Size = new System.Drawing.Size(147, 22);
             this.toolStripMenuItem6.Text = "Unflag All";
             this.toolStripMenuItem6.Click += new System.EventHandler(this.unflagall_Click);
-
-            //
+            // 
             // imagelistDragDrop
-            //
+            // 
             this.imagelistDragDrop.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
             this.imagelistDragDrop.ImageSize = new System.Drawing.Size(16, 16);
             this.imagelistDragDrop.TransparentColor = System.Drawing.Color.Transparent;
-
-            //
+            // 
             // modifiersMenu
-            //
-            this.modifiersMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
-            {
-                this.flagAllToolStripMenuItem, this.unflagAllToolStripMenuItem
-            });
+            // 
+            this.modifiersMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.flagAllToolStripMenuItem,
+            this.unflagAllToolStripMenuItem});
             this.modifiersMenu.Name = "modifiersMenu";
-            this.modifiersMenu.Size = new System.Drawing.Size(153, 114);
-
-            //
+            this.modifiersMenu.Size = new System.Drawing.Size(127, 48);
+            // 
             // flagAllToolStripMenuItem
-            //
+            // 
             this.flagAllToolStripMenuItem.Name = "flagAllToolStripMenuItem";
-            this.flagAllToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.flagAllToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
             this.flagAllToolStripMenuItem.Text = "Flag All";
             this.flagAllToolStripMenuItem.Click += new System.EventHandler(this.ModifiersFlagAll);
-
-            //
+            // 
             // unflagAllToolStripMenuItem
-            //
+            // 
             this.unflagAllToolStripMenuItem.Name = "unflagAllToolStripMenuItem";
-            this.unflagAllToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.unflagAllToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
             this.unflagAllToolStripMenuItem.Text = "Unflag All";
             this.unflagAllToolStripMenuItem.Click += new System.EventHandler(this.ModifiersUnflagAll);
-
-            //
+            // 
             // PatcherForm
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1264, 681);
@@ -610,6 +563,7 @@ namespace Oxide.Patcher
             this.modifiersMenu.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         private System.Windows.Forms.ContextMenuStrip modifiersMenu;

--- a/src/PatcherForm.resx
+++ b/src/PatcherForm.resx
@@ -134,7 +134,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAAK
-        UQAAAk1TRnQBSQFMAgEBGQEAAVABAQFQAQEBEAEAARABAAT/ARkBAAj/AUIBTQE2BwABNgMAASgDAAFA
+        UQAAAk1TRnQBSQFMAgEBGQEAAWABAQFgAQEBEAEAARABAAT/ARkBAAj/AUIBTQE2BwABNgMAASgDAAFA
         AwABcAMAAQEBAAEYBgABVP8AlgABxwHQAfEBkgGmAe0BNwFdAewBIwFPAe0BIwFPAe0BIwFPAe0BIwFP
         Ae0BIwFPAe0BIwFPAe0BIwFPAe0BIwFPAe0BIwFOAe0BLQFWAewBpwG2Ae6WAAFBAWYB7AF8AYUB+gFV
         AXAB+gFPAW0B+gFLAW0B+QFHAWwB+QFDAWsB+QE/AWoB+QE8AWkB+QE5AWkB+AE2AWgB+AE0AWcB+AFj
@@ -510,7 +510,7 @@
     <value>716, 54</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>78</value>
+    <value>83</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -61,9 +61,9 @@ namespace Oxide.Patcher
                 {
                     Console.WriteLine("Failed to locate Oxide.Core.dll!");
                 }
-                else
+                else if (MessageBox.Show("Failed to locate Oxide.Core.dll!\nOpen the instruction page?", "Oxide Patcher", MessageBoxButtons.YesNo, MessageBoxIcon.Error) == DialogResult.Yes)
                 {
-                    MessageBox.Show("Failed to locate Oxide.Core.dll!", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    System.Diagnostics.Process.Start("https://github.com/OxideMod/Oxide.Patcher?tab=readme-ov-file#patching-games");
                 }
 
                 Environment.Exit(0);

--- a/src/Views/HookViewControl.Designer.cs
+++ b/src/Views/HookViewControl.Designer.cs
@@ -38,12 +38,6 @@ namespace Oxide.Patcher.Views
             this.assemblylabel = new System.Windows.Forms.Label();
             this.methodnamelabel = new System.Windows.Forms.Label();
             this.methodnametextbox = new System.Windows.Forms.TextBox();
-            this.buttonholder = new System.Windows.Forms.FlowLayoutPanel();
-            this.flagbutton = new System.Windows.Forms.Button();
-            this.unflagbutton = new System.Windows.Forms.Button();
-            this.applybutton = new System.Windows.Forms.Button();
-            this.deletebutton = new System.Windows.Forms.Button();
-            this.clonebutton = new System.Windows.Forms.Button();
             this.namelabel = new System.Windows.Forms.Label();
             this.nametextbox = new System.Windows.Forms.TextBox();
             this.hooknamelabel = new System.Windows.Forms.Label();
@@ -51,7 +45,12 @@ namespace Oxide.Patcher.Views
             this.basehooklabel = new System.Windows.Forms.Label();
             this.hooknametextbox = new System.Windows.Forms.TextBox();
             this.hooktypedropdown = new System.Windows.Forms.ComboBox();
-            this.basehookdropdown = new System.Windows.Forms.ComboBox();
+            this.buttonholder = new System.Windows.Forms.FlowLayoutPanel();
+            this.applybutton = new System.Windows.Forms.Button();
+            this.deletebutton = new System.Windows.Forms.Button();
+            this.clonebutton = new System.Windows.Forms.Button();
+            this.flagCheckBox = new System.Windows.Forms.CheckBox();
+            this.baseHookBtn = new System.Windows.Forms.Button();
             this.tabview = new System.Windows.Forms.TabControl();
             this.hooksettingstab = new System.Windows.Forms.TabPage();
             this.beforetab = new System.Windows.Forms.TabPage();
@@ -88,7 +87,6 @@ namespace Oxide.Patcher.Views
             this.detailstable.Controls.Add(this.assemblylabel, 0, 0);
             this.detailstable.Controls.Add(this.methodnamelabel, 0, 2);
             this.detailstable.Controls.Add(this.methodnametextbox, 1, 2);
-            this.detailstable.Controls.Add(this.buttonholder, 0, 8);
             this.detailstable.Controls.Add(this.namelabel, 0, 3);
             this.detailstable.Controls.Add(this.nametextbox, 1, 3);
             this.detailstable.Controls.Add(this.hooknamelabel, 0, 4);
@@ -96,7 +94,8 @@ namespace Oxide.Patcher.Views
             this.detailstable.Controls.Add(this.basehooklabel, 0, 7);
             this.detailstable.Controls.Add(this.hooknametextbox, 1, 4);
             this.detailstable.Controls.Add(this.hooktypedropdown, 1, 6);
-            this.detailstable.Controls.Add(this.basehookdropdown, 1, 7);
+            this.detailstable.Controls.Add(this.buttonholder, 0, 8);
+            this.detailstable.Controls.Add(this.baseHookBtn, 1, 7);
             this.detailstable.Dock = System.Windows.Forms.DockStyle.Fill;
             this.detailstable.Location = new System.Drawing.Point(3, 16);
             this.detailstable.Name = "detailstable";
@@ -197,69 +196,6 @@ namespace Oxide.Patcher.Views
             this.methodnametextbox.TabIndex = 0;
             this.methodnametextbox.TabStop = false;
             // 
-            // buttonholder
-            // 
-            this.detailstable.SetColumnSpan(this.buttonholder, 2);
-            this.buttonholder.Controls.Add(this.flagbutton);
-            this.buttonholder.Controls.Add(this.unflagbutton);
-            this.buttonholder.Controls.Add(this.applybutton);
-            this.buttonholder.Controls.Add(this.deletebutton);
-            this.buttonholder.Controls.Add(this.clonebutton);
-            this.buttonholder.Location = new System.Drawing.Point(3, 246);
-            this.buttonholder.Name = "buttonholder";
-            this.buttonholder.Size = new System.Drawing.Size(611, 30);
-            this.buttonholder.TabIndex = 5;
-            // 
-            // flagbutton
-            // 
-            this.flagbutton.Location = new System.Drawing.Point(3, 3);
-            this.flagbutton.Name = "flagbutton";
-            this.flagbutton.Size = new System.Drawing.Size(55, 23);
-            this.flagbutton.TabIndex = 6;
-            this.flagbutton.Text = "Flag";
-            this.flagbutton.UseVisualStyleBackColor = true;
-            this.flagbutton.Click += new System.EventHandler(this.flagbutton_Click);
-            // 
-            // unflagbutton
-            // 
-            this.unflagbutton.Location = new System.Drawing.Point(64, 3);
-            this.unflagbutton.Name = "unflagbutton";
-            this.unflagbutton.Size = new System.Drawing.Size(62, 23);
-            this.unflagbutton.TabIndex = 7;
-            this.unflagbutton.Text = "Unflag";
-            this.unflagbutton.UseVisualStyleBackColor = true;
-            this.unflagbutton.Click += new System.EventHandler(this.unflagbutton_Click);
-            // 
-            // applybutton
-            // 
-            this.applybutton.Location = new System.Drawing.Point(132, 3);
-            this.applybutton.Name = "applybutton";
-            this.applybutton.Size = new System.Drawing.Size(96, 23);
-            this.applybutton.TabIndex = 8;
-            this.applybutton.Text = "Apply Changes";
-            this.applybutton.UseVisualStyleBackColor = true;
-            this.applybutton.Click += new System.EventHandler(this.applybutton_Click);
-            // 
-            // deletebutton
-            // 
-            this.deletebutton.Location = new System.Drawing.Point(234, 3);
-            this.deletebutton.Name = "deletebutton";
-            this.deletebutton.Size = new System.Drawing.Size(87, 23);
-            this.deletebutton.TabIndex = 9;
-            this.deletebutton.Text = "Remove";
-            this.deletebutton.UseVisualStyleBackColor = true;
-            this.deletebutton.Click += new System.EventHandler(this.deletebutton_Click);
-            // 
-            // clonebutton
-            // 
-            this.clonebutton.Location = new System.Drawing.Point(327, 3);
-            this.clonebutton.Name = "clonebutton";
-            this.clonebutton.Size = new System.Drawing.Size(75, 23);
-            this.clonebutton.TabIndex = 10;
-            this.clonebutton.Text = "Clone";
-            this.clonebutton.UseVisualStyleBackColor = true;
-            this.clonebutton.Click += new System.EventHandler(this.clonebutton_Click);
-            // 
             // namelabel
             // 
             this.namelabel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -305,7 +241,7 @@ namespace Oxide.Patcher.Views
             this.basehooklabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.basehooklabel.Location = new System.Drawing.Point(3, 216);
             this.basehooklabel.Name = "basehooklabel";
-            this.basehooklabel.Size = new System.Drawing.Size(126, 27);
+            this.basehooklabel.Size = new System.Drawing.Size(126, 29);
             this.basehooklabel.TabIndex = 9;
             this.basehooklabel.Text = "Base Hook:";
             this.basehooklabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -330,16 +266,75 @@ namespace Oxide.Patcher.Views
             this.hooktypedropdown.TabIndex = 4;
             this.hooktypedropdown.SelectedIndexChanged += new System.EventHandler(this.hooktypedropdown_SelectedIndexChanged);
             // 
-            // basehookdropdown
+            // buttonholder
             // 
-            this.basehookdropdown.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.basehookdropdown.Enabled = false;
-            this.basehookdropdown.FormattingEnabled = true;
-            this.basehookdropdown.Location = new System.Drawing.Point(135, 219);
-            this.basehookdropdown.Name = "basehookdropdown";
-            this.basehookdropdown.Size = new System.Drawing.Size(479, 21);
-            this.basehookdropdown.TabIndex = 5;
-            this.basehookdropdown.SelectedIndexChanged += new System.EventHandler(this.basehookdropdown_SelectedIndexChanged);
+            this.detailstable.SetColumnSpan(this.buttonholder, 2);
+            this.buttonholder.Controls.Add(this.applybutton);
+            this.buttonholder.Controls.Add(this.deletebutton);
+            this.buttonholder.Controls.Add(this.clonebutton);
+            this.buttonholder.Controls.Add(this.flagCheckBox);
+            this.buttonholder.Location = new System.Drawing.Point(3, 248);
+            this.buttonholder.Name = "buttonholder";
+            this.buttonholder.Size = new System.Drawing.Size(611, 30);
+            this.buttonholder.TabIndex = 5;
+            // 
+            // applybutton
+            // 
+            this.applybutton.Location = new System.Drawing.Point(3, 3);
+            this.applybutton.Name = "applybutton";
+            this.applybutton.Size = new System.Drawing.Size(96, 23);
+            this.applybutton.TabIndex = 8;
+            this.applybutton.Text = "Apply Changes";
+            this.applybutton.UseVisualStyleBackColor = true;
+            this.applybutton.Click += new System.EventHandler(this.applybutton_Click);
+            // 
+            // deletebutton
+            // 
+            this.deletebutton.Location = new System.Drawing.Point(105, 3);
+            this.deletebutton.Name = "deletebutton";
+            this.deletebutton.Size = new System.Drawing.Size(87, 23);
+            this.deletebutton.TabIndex = 9;
+            this.deletebutton.Text = "Remove";
+            this.deletebutton.UseVisualStyleBackColor = true;
+            this.deletebutton.Click += new System.EventHandler(this.deletebutton_Click);
+            // 
+            // clonebutton
+            // 
+            this.clonebutton.Location = new System.Drawing.Point(198, 3);
+            this.clonebutton.Name = "clonebutton";
+            this.clonebutton.Size = new System.Drawing.Size(75, 23);
+            this.clonebutton.TabIndex = 10;
+            this.clonebutton.Text = "Clone";
+            this.clonebutton.UseVisualStyleBackColor = true;
+            this.clonebutton.Click += new System.EventHandler(this.clonebutton_Click);
+            // 
+            // checkBoxFlag
+            // 
+            this.flagCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.flagCheckBox.AutoSize = true;
+            this.flagCheckBox.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.flagCheckBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.flagCheckBox.Location = new System.Drawing.Point(279, 3);
+            this.flagCheckBox.Name = "checkBoxFlag";
+            this.flagCheckBox.Size = new System.Drawing.Size(100, 23);
+            this.flagCheckBox.TabIndex = 11;
+            this.flagCheckBox.Text = "Ignore in patch:";
+            this.flagCheckBox.UseVisualStyleBackColor = true;
+            this.flagCheckBox.CheckedChanged += new System.EventHandler(this.checkBoxFlag_CheckedChanged);
+            // 
+            // baseHookBtn
+            // 
+            this.baseHookBtn.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.baseHookBtn.Enabled = false;
+            this.baseHookBtn.Location = new System.Drawing.Point(135, 219);
+            this.baseHookBtn.Name = "baseHookBtn";
+            this.baseHookBtn.Size = new System.Drawing.Size(479, 23);
+            this.baseHookBtn.TabIndex = 12;
+            this.baseHookBtn.Text = "This hook does not have a parent hook.";
+            this.baseHookBtn.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.baseHookBtn.UseVisualStyleBackColor = true;
+            this.baseHookBtn.Click += new System.EventHandler(this.baseHookBtn_Click);
             // 
             // tabview
             // 
@@ -418,8 +413,10 @@ namespace Oxide.Patcher.Views
             this.detailstable.ResumeLayout(false);
             this.detailstable.PerformLayout();
             this.buttonholder.ResumeLayout(false);
+            this.buttonholder.PerformLayout();
             this.tabview.ResumeLayout(false);
             this.ResumeLayout(false);
+
         }
 
         #endregion
@@ -439,9 +436,6 @@ namespace Oxide.Patcher.Views
         private System.Windows.Forms.Label basehooklabel;
         private System.Windows.Forms.TextBox hooknametextbox;
         private System.Windows.Forms.ComboBox hooktypedropdown;
-        private System.Windows.Forms.ComboBox basehookdropdown;
-        private System.Windows.Forms.Button flagbutton;
-        private System.Windows.Forms.Button unflagbutton;
         private System.Windows.Forms.Button applybutton;
         private System.Windows.Forms.TabControl tabview;
         private System.Windows.Forms.TabPage hooksettingstab;
@@ -454,5 +448,7 @@ namespace Oxide.Patcher.Views
         private System.Windows.Forms.TabPage codeaftertab;
         private System.Windows.Forms.TabPage codebeforetab;
         private System.Windows.Forms.Button clonebutton;
+        private System.Windows.Forms.CheckBox flagCheckBox;
+        private System.Windows.Forms.Button baseHookBtn;
     }
 }

--- a/src/Views/ProjectSettingsControl.cs
+++ b/src/Views/ProjectSettingsControl.cs
@@ -47,6 +47,9 @@ namespace Oxide.Patcher
             ProjectObject.Name = nametextbox.Text;
             ProjectObject.TargetDirectory = directorytextbox.Text;
             ProjectObject.Save(ProjectFilename);
+
+            // Updating the window title
+            PatcherForm.MainForm.UpdateWindowTitle();
         }
     }
 }


### PR DESCRIPTION
## Changes
- When opening(without the **-c** argument), if **Oxide.Core.dll** is missing, an option will be provided to open instruction's page [https://github.com/OxideMod/Oxide.Patcher?tab=readme-ov-file#patching-games](https://github.com/OxideMod/Oxide.Patcher?tab=readme-ov-file#patching-games);
- Now, when there is an active project, the window title will display as "**_projectName_ - Oxide Patcher(_version_)**";
- Added the ability to reorder open tabs using drag and drop([StackOverflow solution](https://stackoverflow.com/a/6065769));
- In the **HookView** window, the **Flag** and **Unflag** buttons have been replaced with **CheckBox**, making the purpose of **Flag** more readable and understandable;
- In the **HookView** window, for the **BaseHook**, the control was changed from a **DropDown** to a **Button**, improving text readability.
I didn't quite understand the previous **DropDown** implementation, there were too many unclear iterations over hooks and a new assignment for **BaseHook**;
- In the **HookView** window, for the **BaseHook**, if the **BaseHook** is not null, clicking the button will open a tab with the parent hook. This makes it easier to find the parent hook.