### PR TITLE
Add missing "HookParameters" section for hooks of Type "Modify",

### DIFF
--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-
+using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.Syntax;
-
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Oxide.Patcher.Common;
@@ -56,6 +58,20 @@ namespace Oxide.Patcher.Docs
 
                 case Modify modifyHook:
                     Type = HookType.Modify;
+
+                    // Auto generate hook argument from instructions list or use ArgumentOverride string to generate Docs. 
+                    if (string.IsNullOrEmpty(modifyHook.ArgumentOverride))
+                    {
+                        // Analyse modify instructions to find arguments and return type
+                        (ReturnTypeOverwrite,HookParameters) = GetHookArguments(modifyHook, methodDef);
+                        if (ReturnTypeOverwrite != null) ReturnBehavior = ReturnBehavior.UseArgumentString;
+                    }
+                    else
+                    {
+                        // use override string for argument and return type
+                        (ReturnTypeOverwrite, HookParameters) = GetHookArguments_override(modifyHook, methodDef);
+                        if (ReturnTypeOverwrite != null) ReturnBehavior = ReturnBehavior.UseArgumentString;
+                    }
                     break;
 
                 default:
@@ -193,6 +209,186 @@ namespace Oxide.Patcher.Docs
             return null;
         }
 
+        private (string, Dictionary<string, string>) GetHookArguments(Modify hook, MethodDefinition method)
+        {
+            Dictionary<string, string> hookArguments = new Dictionary<string, string>();
+            bool foundHook = false;
+            //bool processArguments = false;
+            //bool processReturnType = false;
+            ArgSM procState = ArgSM.StartState;
+            ReturnTypeOverwrite = null;
+
+            if (hook.Name == "OnCentralizedBanCheck" || hook.HookName== "OnNpcTarget" || hook.HookName == "OnEngineStart" || hook.HookName == "OnEngineStarted")
+                Console.WriteLine($"hook: {hook.Name} For BreakPoint");
+
+            foreach (var instr in hook.Instructions)
+            {
+                // Interpret IL between ldstr hookname  and the call callhook instruction
+                var split = instr.OpCode.ToLowerInvariant().Split('_');
+                if (procState== ArgSM.StartState && split[0].StartsWith("ldstr") && instr.Operand.Equals(hook.HookName))
+                {
+                    hookArguments.Clear();
+                    procState = ArgSM.GetArgs;
+                }
+                else if (procState == ArgSM.GetArgs &&  split[0].StartsWith("ldstr"))
+                {
+                    hookArguments.Add("str", Utility.TransformType("string"));
+                }
+                else if (procState == ArgSM.GetArgs && split[0].StartsWith("ldc"))
+                {
+					// Its a constant, value is not important for argument list. use 'int condition'
+                    //int cte = ((split.Count() == 3 && split[1].StartsWith("i4") && split[2] == "s") ? Convert.ToInt32(instr.Operand) : Convert.ToInt32(split[2]));
+                    //hookArguments.Add(cte.ToString(), "int32"); // Code use constant, but form plugin POV, its a variable
+                    hookArguments.Add("condition", Utility.TransformType("int"));
+                }
+                else if (procState == ArgSM.GetArgs && split[0].StartsWith("ldarg"))
+                {
+                    string operand;
+                    int index = ((split.Count() == 1 || split[1] == "s") ? Convert.ToInt32(instr.Operand) : Convert.ToInt32(split[1]));
+                    if (index == 0) operand = "this";
+                    else operand = "a" + (index - 1).ToString();
+                    AddHookArguments(operand, method, hookArguments);
+                }
+                else if (procState == ArgSM.GetArgs && split[0].StartsWith("ldloc"))
+                {
+                    string operand;
+                    int index = ((split.Count() == 1 || split[1] == "s") ? Convert.ToInt32(instr.Operand) : Convert.ToInt32(split[1]));
+                    operand = "l" + index.ToString();
+                    AddHookArguments(operand, method, hookArguments);
+                }
+                else if (procState == ArgSM.GetArgs && split[0].StartsWith("ldfld"))
+                {
+                    if (instr.Operand is string str)
+                    {
+                        var opSplit = str.Split('|');
+                        var opCount = opSplit.Count();
+                        if (hookArguments.Count == 0 || opCount != 3) continue;
+
+                        (var fieldName, var fieldType) = ResolveFieldType(opSplit[0], opSplit[1], opSplit[2]);
+                        var type = Utility.TransformType(fieldType);
+                        var key = hookArguments.Last().Key;
+                        hookArguments.Remove(key);     // pop last and update arg
+                        hookArguments.Add(fieldName, string.IsNullOrEmpty(type) ? "object" : type);
+                    }
+                }
+                else if (procState == ArgSM.GetArgs && instr.OpCode.StartsWith("box"))
+                {
+                    if (instr.Operand is string str)
+                    {
+                        var opSplit = str.Split('|');
+                        if (hookArguments.Count == 0) continue;
+                        var key = hookArguments.Last().Key;
+                        hookArguments[key] = Utility.TransformType(opSplit.Last());
+                    }
+                }
+                else if (procState == ArgSM.GetArgs && instr.OpCode.StartsWith("callvirt"))
+                {
+                    if (instr.Operand is string str)
+                    {
+                        // No modify hooks use callvirt at this time
+                        Console.WriteLine($"hook: {hook.Name} use callvirt. Use Argument override string for correct info in doc ");
+                    }
+                }
+                else if (procState == ArgSM.GetArgs && instr.OpCode.StartsWith("call"))
+                {
+                    if (instr.Operand is string str)
+                    {
+                        if (str.Contains("CallHook"))
+                        {
+                            foundHook = true;
+                            procState = ArgSM.GetRetType;
+                            break;
+                        }
+                        else
+                        {
+                            // for now, support simple one param call for type convertion of data
+                            // a call for data conversion should be followed by a box op to get the type.
+                            var opSplit = str.Split('|');
+                            string operand = string.Join(".", opSplit.Skip(1));
+                            if (hookArguments.Count == 0) continue;
+                            var key = hookArguments.Last().Key;
+                            hookArguments.Remove(key);     // pop last
+                            hookArguments.Add(key, Utility.TransformType(operand));
+                            Console.WriteLine($"hook: {hook.Name} use call. Check generated documentation ");
+                        }
+                    }
+                }
+                else if (procState== ArgSM.GetRetType && (instr.OpCode.StartsWith("brtrue") || instr.OpCode.StartsWith("brfalse") || instr.OpCode.StartsWith("ldnull")))
+                {
+                    if (instr.Operand is string str)
+                    {
+                        ReturnTypeOverwrite = "object";
+                        procState = ArgSM.Idle;
+                        break;
+                    }
+                }
+                else if (procState == ArgSM.GetRetType && (instr.OpCode.StartsWith("pop"))) // Callhook return value ignored
+                {
+                    if (instr.Operand is string str)
+                    {
+                        ReturnTypeOverwrite = null;
+                        procState = ArgSM.Idle;
+                        break;
+                    }
+                }
+            }
+            return (ReturnTypeOverwrite, (foundHook ? hookArguments : null));
+        }
+
+        void AddHookArguments(string argument, MethodDefinition method, Dictionary<string, string> hookArguments)
+        {
+            if (string.IsNullOrEmpty(argument)) return;
+
+            string typeName = GetArgStringType(argument, method, out string argName);
+
+            //TODO: think of a better way to handle if there are two args that have the same name
+            if (hookArguments.ContainsKey(argName))
+            {
+                string newArgName = argName;
+
+                int index = 2;
+                while (hookArguments.ContainsKey(newArgName))
+                {
+                    newArgName = $"{argName}{index}";
+                    index++;
+                }
+                hookArguments.Add(newArgName, typeName);
+            }
+            else hookArguments.Add(argName, typeName);
+        }
+
+        private (string, Dictionary<string, string>) GetHookArguments_override(Modify hook, MethodDefinition method)
+        {
+            Dictionary<string, string> hookArguments = new Dictionary<string, string>();
+            ReturnTypeOverwrite = null;
+            if (string.IsNullOrEmpty(hook.ArgumentOverride)) return (null, null);
+            string[] line = hook.ArgumentOverride.Split(':'); // split arg and return type
+            if (!string.IsNullOrEmpty(line[0]))   // no arg to analyse
+            {
+                string[] arguments = line[0].Split(',');
+                int index = 1;
+                string arg;
+                string type;
+                foreach (string argument in arguments)
+                {
+                    string[] typearg = argument.Trim().Split(' ');
+                    if (typearg.Length == 0) break;
+                    if (typearg.Length == 1) arg = $"oxide_{index++}";
+                    else arg = typearg[1];
+                    type = typearg[0];
+                    if (hookArguments.ContainsKey(arg)) arg = $"oxide_{index++}"; // check dup key typo
+                    hookArguments.Add(arg, type);
+                }
+            }
+
+            if (line.Length == 2 && !string.IsNullOrEmpty(line[1])) // use return type if defined
+            {
+                ReturnTypeOverwrite = line[1].Trim();
+            }
+            return (ReturnTypeOverwrite, hookArguments);
+        }
+
+
         //Doesn't work if I use the Decompiler class so just do this for now
         // private static string GetSourceCode(MethodDefinition methodDefinition)
         // {
@@ -236,7 +432,7 @@ namespace Oxide.Patcher.Docs
                 }
 
                 argName = GetLocalVariableName(index, method);
-                return variableType is ByReferenceType byRefType
+                return variableType is Mono.Cecil.ByReferenceType byRefType
                            ? Utility.GetReadableTypeName(byRefType.ElementType)
                            : Utility.GetReadableTypeName(variableType);
             }
@@ -286,7 +482,7 @@ namespace Oxide.Patcher.Docs
             }
 
             argName = "Unknown";
-            return "Unknown";
+            return "object";
         }
 
         private string GetLocalVariableName(int index, MethodDefinition method)
@@ -308,6 +504,40 @@ namespace Oxide.Patcher.Docs
             }
 
             return string.IsNullOrEmpty(ilTypeName) ? $"V_{index}" : char.ToLower(ilTypeName[0]) + ilTypeName.Substring(1);
+        }
+
+        // Probably should be in a different file like decompiler
+        public (string,string) ResolveFieldType(string assemblyPath, string fullTypeName, string fieldName)
+        {
+            string fullpath = Path.Combine(_targetDirectory, $"{assemblyPath}.dll");
+            string typename = fullTypeName.Replace("/", "+");
+
+            var resolver = new UniversalAssemblyResolver(fullpath, false, null);
+            var module = new PEFile(fullpath);
+            var typeSystem = new DecompilerTypeSystem(module, resolver);
+
+            ITypeDefinition typeDef = typeSystem.MainModule.Compilation
+                .FindType(new FullTypeName(typename))
+                .GetDefinition();
+
+            if (typeDef != null)
+            {
+                //var field = typeDef.Fields.FirstOrDefault(f => f.Name == fieldName);
+                var field = typeDef.GetFields().FirstOrDefault(f => f.Name == fieldName);                
+                if (field != null)
+                {
+                    if (field.ReturnType is ITypeParameter typeParam)
+                    {
+                        //int index = typeParam.Index;
+                        return (field.Name, typeParam.EffectiveBaseClass.Name);
+                    }
+                    else
+                    {
+                        return (field.Name, field.Type.ReflectionName);
+                    }
+                }
+            }
+            return ("unknown", "object");
         }
 
         private bool GetMember(MethodDefinition originalMethod, TypeDefinition currentArg, string[] target, out TypeReference finalTypeRef)
@@ -469,6 +699,14 @@ namespace Oxide.Patcher.Docs
         {
             Simple,
             Modify
+        }
+
+        public enum ArgSM
+        {
+            StartState,
+            GetArgs,
+            GetRetType,
+            Idle
         }
     }
 }

--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -292,7 +292,6 @@ namespace Oxide.Patcher.Docs
                         {
                             foundHook = true;
                             procState = ArgSM.GetRetType;
-                            break;
                         }
                         else
                         {
@@ -310,21 +309,15 @@ namespace Oxide.Patcher.Docs
                 }
                 else if (procState== ArgSM.GetRetType && (instr.OpCode.StartsWith("brtrue") || instr.OpCode.StartsWith("brfalse") || instr.OpCode.StartsWith("ldnull")))
                 {
-                    if (instr.Operand is string str)
-                    {
-                        ReturnTypeOverwrite = "object";
-                        procState = ArgSM.Idle;
-                        break;
-                    }
+                    ReturnTypeOverwrite = "object";
+                    procState = ArgSM.Idle;
+                    break;
                 }
                 else if (procState == ArgSM.GetRetType && (instr.OpCode.StartsWith("pop"))) // Callhook return value ignored
                 {
-                    if (instr.Operand is string str)
-                    {
-                        ReturnTypeOverwrite = null;
-                        procState = ArgSM.Idle;
-                        break;
-                    }
+                    ReturnTypeOverwrite = null;
+                    procState = ArgSM.Idle;
+                    break;
                 }
             }
             return (ReturnTypeOverwrite, (foundHook ? hookArguments : null));

--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -213,13 +213,8 @@ namespace Oxide.Patcher.Docs
         {
             Dictionary<string, string> hookArguments = new Dictionary<string, string>();
             bool foundHook = false;
-            //bool processArguments = false;
-            //bool processReturnType = false;
             ArgSM procState = ArgSM.StartState;
             ReturnTypeOverwrite = null;
-
-            if (hook.Name == "OnCentralizedBanCheck" || hook.HookName== "OnNpcTarget" || hook.HookName == "OnEngineStart" || hook.HookName == "OnEngineStarted")
-                Console.WriteLine($"hook: {hook.Name} For BreakPoint");
 
             foreach (var instr in hook.Instructions)
             {
@@ -286,7 +281,7 @@ namespace Oxide.Patcher.Docs
                     if (instr.Operand is string str)
                     {
                         // No modify hooks use callvirt at this time
-                        Console.WriteLine($"hook: {hook.Name} use callvirt. Use Argument override string for correct info in doc ");
+                        //Console.WriteLine($"hook: {hook.Name} use callvirt. Use Argument override string for correct info in doc ");
                     }
                 }
                 else if (procState == ArgSM.GetArgs && instr.OpCode.StartsWith("call"))
@@ -309,7 +304,7 @@ namespace Oxide.Patcher.Docs
                             var key = hookArguments.Last().Key;
                             hookArguments.Remove(key);     // pop last
                             hookArguments.Add(key, Utility.TransformType(operand));
-                            Console.WriteLine($"hook: {hook.Name} use call. Check generated documentation ");
+                            //Console.WriteLine($"hook: {hook.Name} use call. Check generated documentation ");
                         }
                     }
                 }
@@ -522,7 +517,6 @@ namespace Oxide.Patcher.Docs
 
             if (typeDef != null)
             {
-                //var field = typeDef.Fields.FirstOrDefault(f => f.Name == fieldName);
                 var field = typeDef.GetFields().FirstOrDefault(f => f.Name == fieldName);                
                 if (field != null)
                 {

--- a/src/OpjData/Hooks/Modify.cs
+++ b/src/OpjData/Hooks/Modify.cs
@@ -44,6 +44,8 @@ namespace Oxide.Patcher.Hooks
 
         private Dictionary<string, OpCode> opCodes = typeof(OpCodes).GetFields(BindingFlags.Static | BindingFlags.Public).ToDictionary(f => f.Name.ToLower(), f => (OpCode)f.GetValue(null));
 
+        public string ArgumentOverride { get; set; } = null;
+
         public override bool ApplyPatch(MethodDefinition original, ILWeaver weaver, Patching.Patcher patcher = null)
         {
             List<Instruction> insts = new List<Instruction>();

--- a/src/Views/ModifyHookSettingsControl.Designer.cs
+++ b/src/Views/ModifyHookSettingsControl.Designer.cs
@@ -30,6 +30,9 @@
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label4 = new System.Windows.Forms.Label();
+            this.argumentOverride = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.injectionindex = new System.Windows.Forms.NumericUpDown();
             this.illist = new System.Windows.Forms.ListBox();
@@ -48,29 +51,68 @@
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 120F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 269F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.label4, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.argumentOverride, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.injectionindex, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.illist, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.removecount, 1, 1);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(5, 5);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 39F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 39F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(344, 247);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(833, 380);
             this.tableLayoutPanel1.TabIndex = 1;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label4.Location = new System.Drawing.Point(5, 343);
+            this.label4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(259, 37);
+            this.label4.TabIndex = 12;
+            this.label4.Text = "type var, type var:returntype";
+            // 
+            // argumentOverride
+            // 
+            this.argumentOverride.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.argumentOverride.Location = new System.Drawing.Point(274, 323);
+            this.argumentOverride.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.argumentOverride.Name = "argumentOverride";
+            this.argumentOverride.Size = new System.Drawing.Size(554, 22);
+            this.argumentOverride.TabIndex = 11;
+            this.argumentOverride.TextChanged += new System.EventHandler(this.argumentstring_TextChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label3.Location = new System.Drawing.Point(5, 318);
+            this.label3.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(259, 25);
+            this.label3.TabIndex = 5;
+            this.label3.Text = "Argument override";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // label1
             // 
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Location = new System.Drawing.Point(4, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(114, 26);
+            this.label1.Size = new System.Drawing.Size(261, 39);
             this.label1.TabIndex = 0;
             this.label1.Text = "Injection Index:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -78,14 +120,15 @@
             // injectionindex
             // 
             this.injectionindex.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.injectionindex.Location = new System.Drawing.Point(123, 3);
+            this.injectionindex.Location = new System.Drawing.Point(273, 4);
+            this.injectionindex.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.injectionindex.Maximum = new decimal(new int[] {
             5000,
             0,
             0,
             0});
             this.injectionindex.Name = "injectionindex";
-            this.injectionindex.Size = new System.Drawing.Size(218, 20);
+            this.injectionindex.Size = new System.Drawing.Size(556, 22);
             this.injectionindex.TabIndex = 2;
             this.injectionindex.ValueChanged += new System.EventHandler(this.injectionindex_ValueChanged);
             // 
@@ -95,25 +138,28 @@
             this.illist.ContextMenuStrip = this.listContextMenuStrip;
             this.illist.Dock = System.Windows.Forms.DockStyle.Fill;
             this.illist.FormattingEnabled = true;
-            this.illist.Location = new System.Drawing.Point(3, 55);
+            this.illist.ItemHeight = 16;
+            this.illist.Location = new System.Drawing.Point(4, 82);
+            this.illist.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.illist.Name = "illist";
-            this.illist.Size = new System.Drawing.Size(338, 189);
+            this.illist.Size = new System.Drawing.Size(825, 232);
             this.illist.TabIndex = 4;
             this.illist.SelectedIndexChanged += new System.EventHandler(this.illist_SelectedIndexChanged);
             // 
             // listContextMenuStrip
             // 
+            this.listContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.listContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.NewToolStripMenuItem,
             this.EditToolStripMenuItem,
             this.RemoveToolStripMenuItem});
             this.listContextMenuStrip.Name = "listContextMenuStrip";
-            this.listContextMenuStrip.Size = new System.Drawing.Size(118, 70);
+            this.listContextMenuStrip.Size = new System.Drawing.Size(133, 76);
             // 
             // NewToolStripMenuItem
             // 
             this.NewToolStripMenuItem.Name = "NewToolStripMenuItem";
-            this.NewToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.NewToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.NewToolStripMenuItem.Text = "New";
             this.NewToolStripMenuItem.Click += new System.EventHandler(this.NewToolStripMenuItem_Click);
             // 
@@ -121,7 +167,7 @@
             // 
             this.EditToolStripMenuItem.Enabled = false;
             this.EditToolStripMenuItem.Name = "EditToolStripMenuItem";
-            this.EditToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.EditToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.EditToolStripMenuItem.Text = "Edit";
             this.EditToolStripMenuItem.Click += new System.EventHandler(this.EditToolStripMenuItem_Click);
             // 
@@ -129,7 +175,7 @@
             // 
             this.RemoveToolStripMenuItem.Enabled = false;
             this.RemoveToolStripMenuItem.Name = "RemoveToolStripMenuItem";
-            this.RemoveToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.RemoveToolStripMenuItem.Size = new System.Drawing.Size(132, 24);
             this.RemoveToolStripMenuItem.Text = "Remove";
             this.RemoveToolStripMenuItem.Click += new System.EventHandler(this.RemoveToolStripMenuItem_Click);
             // 
@@ -137,9 +183,10 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label2.Location = new System.Drawing.Point(3, 26);
+            this.label2.Location = new System.Drawing.Point(4, 39);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(114, 26);
+            this.label2.Size = new System.Drawing.Size(261, 39);
             this.label2.TabIndex = 1;
             this.label2.Text = "Remove Count:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -147,20 +194,21 @@
             // removecount
             // 
             this.removecount.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.removecount.Location = new System.Drawing.Point(123, 29);
+            this.removecount.Location = new System.Drawing.Point(273, 43);
+            this.removecount.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.removecount.Name = "removecount";
-            this.removecount.Size = new System.Drawing.Size(218, 20);
+            this.removecount.Size = new System.Drawing.Size(556, 22);
             this.removecount.TabIndex = 3;
             this.removecount.ValueChanged += new System.EventHandler(this.removecount_ValueChanged);
-            this.removecount.Minimum = 0;
             // 
             // ModifyHookSettingsControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel1);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "ModifyHookSettingsControl";
-            this.Size = new System.Drawing.Size(612, 250);
+            this.Size = new System.Drawing.Size(859, 397);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.injectionindex)).EndInit();
@@ -182,5 +230,8 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.NumericUpDown removecount;
         private System.Windows.Forms.ToolStripMenuItem RemoveToolStripMenuItem;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.TextBox argumentOverride;
+        private System.Windows.Forms.Label label4;
     }
 }

--- a/src/Views/ModifyHookSettingsControl.cs
+++ b/src/Views/ModifyHookSettingsControl.cs
@@ -26,7 +26,7 @@ namespace Oxide.Patcher.Views
             removecount.Maximum = method.Body.Instructions.Count - 1;
             removecount.Value = Hook.RemoveCount;
             illist.DataSource = new BindingSource { DataSource = Hook.Instructions };
-
+            argumentOverride.Text = string.IsNullOrEmpty(Hook.ArgumentOverride) ? string.Empty : Hook.ArgumentOverride;
             _loaded = true;
         }
 
@@ -100,6 +100,16 @@ namespace Oxide.Patcher.Views
         {
             Hook.Instructions.RemoveAt(illist.SelectedIndex);
             ((BindingSource)illist.DataSource).ResetBindings(false);
+            NotifyChanges();
+        }
+
+        private void argumentstring_TextChanged(object sender, EventArgs e)
+        {
+            if (!_loaded)
+            {
+                return;
+            }
+            Hook.ArgumentOverride = string.IsNullOrEmpty(argumentOverride.Text) ? null : argumentOverride.Text;
             NotifyChanges();
         }
     }


### PR DESCRIPTION
This is for DOC generation only.
Add missing "HookParameters" section for hooks of Type "Modify",
Parse the IL in the instruction list to generate the argument list. If the generated argument list is not satisfactory, an alternative method is to add a "argumentOverride" entry in the modify dialog The "argumentOverride" string is formatted like : "datatype1 var1, datatype2 var2, datatype3 var3:returnType", Auto argument by default when "argumentOverride" is empty or non existant in .OPJ