### PR TITLE
Highlight flagged items in tree view with red text and category count

### DIFF
--- a/src/PatcherForm.cs
+++ b/src/PatcherForm.cs
@@ -551,8 +551,10 @@ namespace Oxide.Patcher
             TreeNode node = objectview.SelectedNode;
             if (node != null && (string)node.Tag == "Hooks")
             {
-                TreeNode category = new TreeNode($"New Category {newCategoryCount++}")
+                string catName = $"New Category {newCategoryCount++}";
+                TreeNode category = new TreeNode(catName)
                 {
+                    Name = catName,
                     Tag = "Category",
                     ImageKey = "folder.png",
                     SelectedImageKey = "folder.png"
@@ -965,6 +967,7 @@ namespace Oxide.Patcher
                     {
                         hooknode.ImageKey = "script_error.png";
                         hooknode.SelectedImageKey = "script_error.png";
+                        hooknode.ForeColor = Color.Red;
                     }
                     else
                     {
@@ -988,6 +991,19 @@ namespace Oxide.Patcher
 
                         category.ImageKey = "folder_flagged.png";
                         category.SelectedImageKey = "folder_flagged.png";
+                        category.ForeColor = Color.Red;
+                    }
+                }
+
+                foreach (TreeNode node in hooks.Nodes)
+                {
+                    if ((string)node.Tag == "Category")
+                    {
+                        int flagged = node.Nodes.Cast<TreeNode>().Count(n => (n.Tag as Hook)?.Flagged == true);
+                        if (flagged > 0)
+                        {
+                            node.Text = $"{node.Name} ({flagged} flagged)";
+                        }
                     }
                 }
 
@@ -1014,6 +1030,7 @@ namespace Oxide.Patcher
                     {
                         modifiernode.ImageKey = "script_error.png";
                         modifiernode.SelectedImageKey = "script_error.png";
+                        modifiernode.ForeColor = Color.Red;
                     }
                     else
                     {
@@ -1048,6 +1065,7 @@ namespace Oxide.Patcher
                     {
                         fieldnode.ImageKey = "script_error.png";
                         fieldnode.SelectedImageKey = "script_error.png";
+                        fieldnode.ForeColor = Color.Red;
                     }
                     else
                     {
@@ -1388,7 +1406,7 @@ namespace Oxide.Patcher
 
         private bool CategoryExists(string label)
         {
-            return objectview.Nodes["Hooks"].Nodes.Cast<TreeNode>().Any(node => node.Text == label);
+            return objectview.Nodes["Hooks"].Nodes.Cast<TreeNode>().Any(node => node.Name == label);
         }
 
         private void Sort(TreeNodeCollection nodes, bool subNodes = true)
@@ -1647,6 +1665,7 @@ namespace Oxide.Patcher
             {
                 hooknode.ImageKey = "script_error.png";
                 hooknode.SelectedImageKey = "script_error.png";
+                hooknode.ForeColor = Color.Red;
             }
             else
             {
@@ -1687,6 +1706,7 @@ namespace Oxide.Patcher
             {
                 modifiernode.ImageKey = "script_error.png";
                 modifiernode.SelectedImageKey = "script_error.png";
+                modifiernode.ForeColor = Color.Red;
             }
             else
             {
@@ -1728,6 +1748,7 @@ namespace Oxide.Patcher
             {
                 fieldnode.ImageKey = "script_error.png";
                 fieldnode.SelectedImageKey = "script_error.png";
+                fieldnode.ForeColor = Color.Red;
             }
             else
             {
@@ -1923,6 +1944,7 @@ namespace Oxide.Patcher
 
                 node.ImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
                 node.SelectedImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
+                node.ForeColor = hook.Flagged ? Color.Red : Color.Empty;
 
                 if (node.Text != hook.Name)
                 {
@@ -1955,24 +1977,24 @@ namespace Oxide.Patcher
 
                 hookNode.ImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
                 hookNode.SelectedImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
+                hookNode.ForeColor = hook.Flagged ? Color.Red : Color.Empty;
             }
 
-            bool anyFlagged = false;
+            int flaggedCount = 0;
 
             //Change icon if any hooks are flagged
             foreach (TreeNode subNode in categoryNode.Nodes)
             {
-                if (!(subNode.Tag is Hook tagHook) || !tagHook.Flagged)
+                if (subNode.Tag is Hook tagHook && tagHook.Flagged)
                 {
-                    continue;
+                    flaggedCount++;
                 }
-
-                anyFlagged = true;
-                break;
             }
 
-            categoryNode.ImageKey = anyFlagged ? "folder_flagged.png" : "folder.png";
-            categoryNode.SelectedImageKey = anyFlagged ? "folder_flagged.png" : "folder.png";
+            categoryNode.Text = flaggedCount > 0 ? $"{categoryNode.Name} ({flaggedCount} flagged)" : categoryNode.Name;
+            categoryNode.ImageKey = flaggedCount > 0 ? "folder_flagged.png" : "folder.png";
+            categoryNode.SelectedImageKey = flaggedCount > 0 ? "folder_flagged.png" : "folder.png";
+            categoryNode.ForeColor = flaggedCount > 0 ? Color.Red : Color.Empty;
 
             if (shouldSort)
             {
@@ -2021,6 +2043,7 @@ namespace Oxide.Patcher
 
                 treeNode.ImageKey = modifier.Flagged ? "script_error.png" : "script_lightning.png";
                 treeNode.SelectedImageKey = modifier.Flagged ? "script_error.png" : "script_lightning.png";
+                treeNode.ForeColor = modifier.Flagged ? Color.Red : Color.Empty;
 
                 if (treeNode.Text != modifier.Name)
                 {
@@ -2088,11 +2111,13 @@ namespace Oxide.Patcher
                     {
                         treenode.ImageKey = "script_error.png";
                         treenode.SelectedImageKey = "script_error.png";
+                        treenode.ForeColor = Color.Red;
                     }
                     else
                     {
                         treenode.ImageKey = "script_lightning.png";
                         treenode.SelectedImageKey = "script_lightning.png";
+                        treenode.ForeColor = Color.Empty;
                     }
                     Sort(fields.Nodes);
                     break;


### PR DESCRIPTION
Improves visual visibility for flagged tree nodes:
- Sets `ForeColor = Color.Red` on flagged hooks, modifiers, fields, and their parent category folders.
- Appends `(X flagged)` to category folder text when it contains flagged hooks.


<img width="380" height="728" alt="image" src="https://github.com/user-attachments/assets/c55e44ef-5a4a-4215-a76b-b6ea5282bcdd" />
