### PR TITLE
Add Docs Placement tab to view CodeAfterInjection from previous documentation file as a reference when patching.

### DIFF
--- a/src/Common/UserSettings.cs
+++ b/src/Common/UserSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
 using Newtonsoft.Json;
@@ -29,6 +29,11 @@ namespace Oxide.Patcher.Common
         /// Gets or sets the last directory used to open or save a project
         /// </summary>
         public string LastProjectDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the docs.json path
+        /// </summary>
+        public string DocsPath { get; set; } = string.Empty;
 
         // The settings filename
         private const string FileName = "oxide-patcher-settings.json";

--- a/src/Docs/DocsCache.cs
+++ b/src/Docs/DocsCache.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Oxide.Patcher.Docs
+{
+    public static class DocsCache
+    {
+        private class CacheEntry
+        {
+            public DateTime LastWriteTimeUtc { get; set; }
+            public DocsData Data { get; set; }
+        }
+
+        private static readonly ConcurrentDictionary<string, CacheEntry> _cache = new ConcurrentDictionary<string, CacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Loads and caches DocsData from the specified file path, reloading only when the file on disk changes.
+        /// </summary>
+        public static DocsData GetDocs(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                DateTime currentWriteTime = File.GetLastWriteTimeUtc(filePath);
+
+                if (_cache.TryGetValue(filePath, out CacheEntry entry) && entry.LastWriteTimeUtc == currentWriteTime)
+                {
+                    return entry.Data;
+                }
+
+                string json = File.ReadAllText(filePath);
+                DocsData data = JsonConvert.DeserializeObject<DocsData>(json);
+
+                if (data != null)
+                {
+                    _cache[filePath] = new CacheEntry
+                    {
+                        LastWriteTimeUtc = currentWriteTime,
+                        Data = data
+                    };
+                }
+
+                return data;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[DocsCache] Error loading docs from '{filePath}': {ex}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Looks up the CodeAfterInjection for the given hook name in the specified docs file.
+        /// </summary>
+        public static string GetDocsPlacement(string filePath, string hookName)
+        {
+            DocsData data = GetDocs(filePath);
+            if (data?.Hooks == null || string.IsNullOrEmpty(hookName))
+            {
+                return null;
+            }
+
+            DocsHook hook = data.Hooks.FirstOrDefault(h => string.Equals(h.Name, hookName, StringComparison.OrdinalIgnoreCase))
+                         ?? data.Hooks.FirstOrDefault(h => string.Equals(h.HookName, hookName, StringComparison.OrdinalIgnoreCase));
+
+            return hook?.CodeAfterInjection;
+        }
+    }
+}

--- a/src/Docs/DocsHook.cs
+++ b/src/Docs/DocsHook.cs
@@ -38,6 +38,10 @@ namespace Oxide.Patcher.Docs
         private readonly CSharpDecompiler _decompiler;
         private SyntaxTree _syntaxTree;
 
+        public DocsHook()
+        {
+        }
+
         public DocsHook(Hook hook, MethodDefinition methodDef, CSharpDecompiler decompiler, string targetDirectory)
         {
             _decompiler = decompiler;

--- a/src/Docs/DocsMethodData.cs
+++ b/src/Docs/DocsMethodData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Mono.Cecil;
 using Oxide.Patcher.Common;
 
@@ -9,6 +9,10 @@ namespace Oxide.Patcher.Docs
         public string MethodName { get; set; }
         public string ReturnType { get; set; }
         public Dictionary<string, string> Arguments { get; set; } = new Dictionary<string, string>();
+
+        public DocsMethodData()
+        {
+        }
 
         public DocsMethodData(MethodDefinition methodDef)
         {

--- a/src/PatcherForm.cs
+++ b/src/PatcherForm.cs
@@ -42,6 +42,11 @@ namespace Oxide.Patcher
         /// </summary>
         public UserSettings Settings { get; private set; }
 
+        /// <summary>
+        /// Gets or sets whether the user skipped the prompt to locate docs.json
+        /// </summary>
+        public bool DocsPathPromptSkipped { get; set; }
+
         private Version version = Assembly.GetExecutingAssembly().GetName().Version;
 
         private MouseEventArgs mea;

--- a/src/Views/HookViewControl.Designer.cs
+++ b/src/Views/HookViewControl.Designer.cs
@@ -58,6 +58,7 @@ namespace Oxide.Patcher.Views
             this.aftertab = new System.Windows.Forms.TabPage();
             this.codebeforetab = new System.Windows.Forms.TabPage();
             this.codeaftertab = new System.Windows.Forms.TabPage();
+            this.docsplacementtab = new System.Windows.Forms.TabPage();
             this.detailsgroup.SuspendLayout();
             this.detailstable.SuspendLayout();
             this.buttonholder.SuspendLayout();
@@ -348,6 +349,7 @@ namespace Oxide.Patcher.Views
             this.tabview.Controls.Add(this.aftertab);
             this.tabview.Controls.Add(this.codebeforetab);
             this.tabview.Controls.Add(this.codeaftertab);
+            this.tabview.Controls.Add(this.docsplacementtab);
             this.tabview.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabview.Location = new System.Drawing.Point(5, 305);
             this.tabview.Name = "tabview";
@@ -405,6 +407,16 @@ namespace Oxide.Patcher.Views
             this.codeaftertab.Text = "Code After";
             this.codeaftertab.UseVisualStyleBackColor = true;
             // 
+            // docsplacementtab
+            // 
+            this.docsplacementtab.Location = new System.Drawing.Point(4, 22);
+            this.docsplacementtab.Name = "docsplacementtab";
+            this.docsplacementtab.Padding = new System.Windows.Forms.Padding(3);
+            this.docsplacementtab.Size = new System.Drawing.Size(615, 143);
+            this.docsplacementtab.TabIndex = 5;
+            this.docsplacementtab.Text = "Docs Placement";
+            this.docsplacementtab.UseVisualStyleBackColor = true;
+            // 
             // HookViewControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -453,6 +465,7 @@ namespace Oxide.Patcher.Views
         private System.Windows.Forms.TextBox assemblytextbox;
         private System.Windows.Forms.TabPage codeaftertab;
         private System.Windows.Forms.TabPage codebeforetab;
+        private System.Windows.Forms.TabPage docsplacementtab;
         private System.Windows.Forms.Button clonebutton;
     }
 }

--- a/src/Views/HookViewControl.cs
+++ b/src/Views/HookViewControl.cs
@@ -1,4 +1,4 @@
-﻿using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 using Mono.Cecil;
 using Oxide.Patcher.Hooks;
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Oxide.Patcher.Common;
 using Oxide.Patcher.Common.TextHighlighting;
+using Oxide.Patcher.Docs;
 
 namespace Oxide.Patcher.Views
 {
@@ -31,7 +32,7 @@ namespace Oxide.Patcher.Views
 
         public Button UnflagButton { get; set; }
 
-        private TextEditorControl _msilBefore, _msilAfter, _codeBefore, _codeAfter;
+        private TextEditorControl _msilBefore, _msilAfter, _codeBefore, _codeAfter, _docsPlacement;
 
         private MethodDefinition _methodDef;
         private MethodDefinition _methodDefAfter;
@@ -168,6 +169,16 @@ namespace Oxide.Patcher.Views
                     TextAlign = ContentAlignment.MiddleCenter
                 });
 
+                string missingMethodDocsCode = GetDocsPlacementCode();
+                _docsPlacement = new TextEditorControl
+                {
+                    Dock = DockStyle.Fill,
+                    Text = missingMethodDocsCode,
+                    Document = { HighlightingStrategy = HighlightingManager.Manager.FindHighlighter("C#") },
+                    IsReadOnly = true
+                };
+                docsplacementtab.Controls.Add(_docsPlacement);
+
                 _loaded = true;
                 return;
             }
@@ -202,6 +213,76 @@ namespace Oxide.Patcher.Views
                 IsReadOnly = true
             };
             codeaftertab.Controls.Add(_codeAfter);
+
+            string docsPlacementCode = GetDocsPlacementCode();
+            _docsPlacement = new TextEditorControl
+            {
+                Dock = DockStyle.Fill,
+                Text = docsPlacementCode,
+                Document = { HighlightingStrategy = HighlightingManager.Manager.FindHighlighter("C#") },
+                IsReadOnly = true
+            };
+            docsplacementtab.Controls.Add(_docsPlacement);
+        }
+
+        private string GetDocsPlacementCode()
+        {
+            string docsPath = MainForm?.Settings?.DocsPath;
+            if (string.IsNullOrWhiteSpace(docsPath) && MainForm != null && !MainForm.DocsPathPromptSkipped)
+            {
+                DialogResult result = MessageBox.Show(
+                    "Docs path is not defined. Would you like to locate the 'docs.json' file now?",
+                    "Oxide Patcher",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question);
+
+                if (result == DialogResult.Yes)
+                {
+                    using (OpenFileDialog ofd = new OpenFileDialog())
+                    {
+                        ofd.Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*";
+                        ofd.Title = "Select Docs JSON File";
+                        if (!string.IsNullOrEmpty(MainForm.CurrentProject?.TargetDirectory) && System.IO.Directory.Exists(MainForm.CurrentProject.TargetDirectory))
+                        {
+                            ofd.InitialDirectory = MainForm.CurrentProject.TargetDirectory;
+                        }
+
+                        if (ofd.ShowDialog(this) == DialogResult.OK)
+                        {
+                            docsPath = ofd.FileName;
+                            MainForm.Settings.DocsPath = docsPath;
+                            MainForm.Settings.Save();
+                        }
+                    }
+                }
+                else
+                {
+                    MainForm.DocsPathPromptSkipped = true;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(docsPath))
+            {
+                return "// No Docs Path configured in Project Settings.";
+            }
+
+            if (!System.IO.File.Exists(docsPath))
+            {
+                return $"// Docs file not found: {docsPath}";
+            }
+
+            string docsCode = DocsCache.GetDocsPlacement(docsPath, Hook.Name);
+            if (string.IsNullOrEmpty(docsCode) && !string.IsNullOrEmpty(Hook.HookName))
+            {
+                docsCode = DocsCache.GetDocsPlacement(docsPath, Hook.HookName);
+            }
+
+            if (string.IsNullOrEmpty(docsCode))
+            {
+                return "// Hook not found in docs.json or has no docs placement code.";
+            }
+
+            return docsCode;
         }
 
         private (string msilBefore, string msilAfter, bool patchApplied, Task<string> beforeTask, Task<string> afterTask) BuildBeforeAfter()

--- a/src/Views/ProjectSettingsControl.Designer.cs
+++ b/src/Views/ProjectSettingsControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Oxide.Patcher
+namespace Oxide.Patcher
 {
     partial class ProjectSettingsControl
     {
@@ -30,6 +30,9 @@
         {
             this.settingsgroup = new System.Windows.Forms.GroupBox();
             this.tablepanel = new System.Windows.Forms.TableLayoutPanel();
+            this.selectdocspathbutton = new System.Windows.Forms.Button();
+            this.docspathtextbox = new System.Windows.Forms.TextBox();
+            this.docspathlabel = new System.Windows.Forms.Label();
             this.selectfilenamebutton = new System.Windows.Forms.Button();
             this.filenamelabel = new System.Windows.Forms.Label();
             this.filenametextbox = new System.Windows.Forms.TextBox();
@@ -49,7 +52,7 @@
             this.settingsgroup.Dock = System.Windows.Forms.DockStyle.Top;
             this.settingsgroup.Location = new System.Drawing.Point(0, 0);
             this.settingsgroup.Name = "settingsgroup";
-            this.settingsgroup.Size = new System.Drawing.Size(505, 94);
+            this.settingsgroup.Size = new System.Drawing.Size(505, 124);
             this.settingsgroup.TabIndex = 1;
             this.settingsgroup.TabStop = false;
             this.settingsgroup.Text = "Project Settings";
@@ -60,9 +63,12 @@
             this.tablepanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
             this.tablepanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tablepanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tablepanel.Controls.Add(this.selectdocspathbutton, 2, 3);
+            this.tablepanel.Controls.Add(this.docspathtextbox, 1, 3);
+            this.tablepanel.Controls.Add(this.docspathlabel, 0, 3);
             this.tablepanel.Controls.Add(this.selectfilenamebutton, 2, 2);
             this.tablepanel.Controls.Add(this.filenamelabel, 0, 2);
-            this.tablepanel.Controls.Add(this.filenametextbox, 0, 2);
+            this.tablepanel.Controls.Add(this.filenametextbox, 1, 2);
             this.tablepanel.Controls.Add(this.directorylabel, 0, 1);
             this.tablepanel.Controls.Add(this.namelabel, 0, 0);
             this.tablepanel.Controls.Add(this.nametextbox, 1, 0);
@@ -71,12 +77,42 @@
             this.tablepanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tablepanel.Location = new System.Drawing.Point(3, 16);
             this.tablepanel.Name = "tablepanel";
-            this.tablepanel.RowCount = 3;
+            this.tablepanel.RowCount = 4;
             this.tablepanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.tablepanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.tablepanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tablepanel.Size = new System.Drawing.Size(499, 75);
+            this.tablepanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tablepanel.Size = new System.Drawing.Size(499, 105);
             this.tablepanel.TabIndex = 0;
+            // 
+            // selectdocspathbutton
+            // 
+            this.selectdocspathbutton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.selectdocspathbutton.Location = new System.Drawing.Point(469, 78);
+            this.selectdocspathbutton.Name = "selectdocspathbutton";
+            this.selectdocspathbutton.Size = new System.Drawing.Size(27, 24);
+            this.selectdocspathbutton.TabIndex = 11;
+            this.selectdocspathbutton.Text = "...";
+            this.selectdocspathbutton.UseVisualStyleBackColor = true;
+            this.selectdocspathbutton.Click += new System.EventHandler(this.selectdocspathbutton_Click);
+            // 
+            // docspathtextbox
+            // 
+            this.docspathtextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.docspathtextbox.Location = new System.Drawing.Point(103, 78);
+            this.docspathtextbox.Name = "docspathtextbox";
+            this.docspathtextbox.Size = new System.Drawing.Size(360, 20);
+            this.docspathtextbox.TabIndex = 10;
+            // 
+            // docspathlabel
+            // 
+            this.docspathlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.docspathlabel.Location = new System.Drawing.Point(3, 75);
+            this.docspathlabel.Name = "docspathlabel";
+            this.docspathlabel.Size = new System.Drawing.Size(94, 30);
+            this.docspathlabel.TabIndex = 9;
+            this.docspathlabel.Text = "Docs Path:";
+            this.docspathlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // selectfilenamebutton
             // 
@@ -198,5 +234,8 @@
         private System.Windows.Forms.Button selectdirectorybutton;
         private System.Windows.Forms.TextBox directorytextbox;
         private System.Windows.Forms.Button savebutton;
+        private System.Windows.Forms.Label docspathlabel;
+        private System.Windows.Forms.TextBox docspathtextbox;
+        private System.Windows.Forms.Button selectdocspathbutton;
     }
 }

--- a/src/Views/ProjectSettingsControl.cs
+++ b/src/Views/ProjectSettingsControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Windows.Forms;
 
@@ -20,6 +20,35 @@ namespace Oxide.Patcher
             nametextbox.Text = ProjectObject.Name;
             directorytextbox.Text = ProjectObject.TargetDirectory;
             filenametextbox.Text = ProjectFilename;
+            docspathtextbox.Text = PatcherForm.MainForm?.Settings?.DocsPath ?? string.Empty;
+        }
+
+        private void selectdocspathbutton_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog ofd = new OpenFileDialog())
+            {
+                ofd.Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*";
+                ofd.Title = "Select Docs JSON File";
+                if (!string.IsNullOrEmpty(docspathtextbox.Text) && File.Exists(docspathtextbox.Text))
+                {
+                    ofd.InitialDirectory = Path.GetDirectoryName(docspathtextbox.Text);
+                    ofd.FileName = Path.GetFileName(docspathtextbox.Text);
+                }
+                else if (!string.IsNullOrEmpty(ProjectObject?.TargetDirectory) && Directory.Exists(ProjectObject.TargetDirectory))
+                {
+                    ofd.InitialDirectory = ProjectObject.TargetDirectory;
+                }
+
+                if (ofd.ShowDialog(this) == DialogResult.OK)
+                {
+                    docspathtextbox.Text = ofd.FileName;
+                    if (PatcherForm.MainForm?.Settings != null)
+                    {
+                        PatcherForm.MainForm.Settings.DocsPath = ofd.FileName;
+                        PatcherForm.MainForm.Settings.Save();
+                    }
+                }
+            }
         }
 
         private void savebutton_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Add a "Docs Placement" tab in HookViewControl displaying CodeAfterInjection from docs.json
- Add DocsPath setting to UserSettings to persist the file location
- Prompt to locate docs.json on first hook view if undefined, with an option to skip

This is helpful when patching (atleast for me) to know where the intended placement is for a flagged hook.

<img width="1320" height="506" alt="image" src="https://github.com/user-attachments/assets/f932c30f-9a95-4499-af21-7ed070f5c2db" />
