### PR TITLE
QOL Improvements

### DIFF
--- a/src/Common/AssemblyLoader.cs
+++ b/src/Common/AssemblyLoader.cs
@@ -62,6 +62,7 @@ namespace Oxide.Patcher.Common
                     foreach (Hook hook in manifest.Hooks)
                     {
                         hook.Flagged = true;
+                        hook.FlagReason = "Assembly no longer exists.";
                     }
 
                     continue;
@@ -74,6 +75,7 @@ namespace Oxide.Patcher.Common
                     {
                         missingMethods++;
                         hook.Flagged = true;
+                        hook.FlagReason = "Referenced method no longer exists.";
                     }
                     else
                     {
@@ -83,6 +85,7 @@ namespace Oxide.Patcher.Common
                             changedMethods++;
                             hook.MSILHash = hash;
                             hook.Flagged = true;
+                            hook.FlagReason = "Referenced method has changed.";
                         }
                     }
                 }
@@ -97,6 +100,7 @@ namespace Oxide.Patcher.Common
                             {
                                 changedFields++;
                                 modifier.Flagged = true;
+                                modifier.FlagReason = "Altered modifier.";
                             }
                             break;
 
@@ -106,6 +110,7 @@ namespace Oxide.Patcher.Common
                             {
                                 changedModMethods++;
                                 modifier.Flagged = true;
+                                modifier.FlagReason = "Altered modifier.";
                             }
                             break;
 
@@ -115,6 +120,7 @@ namespace Oxide.Patcher.Common
                             {
                                 changedProperties++;
                                 modifier.Flagged = true;
+                                modifier.FlagReason = "Altered modifier.";
                             }
                             break;
                     }
@@ -129,6 +135,7 @@ namespace Oxide.Patcher.Common
 
                     changedNewFields++;
                     field.Flagged = true;
+                    field.FlagReason = "Target field is no longer valid.";
                 }
             }
 

--- a/src/Common/TextHighlighting/HighlightGroup.cs
+++ b/src/Common/TextHighlighting/HighlightGroup.cs
@@ -43,6 +43,15 @@ namespace Oxide.Patcher.Common.TextHighlighting
             }
         }
 
+        /// <summary>
+        /// Removes all markers previously added through this group, so it can be reused
+        /// (e.g. when the underlying text is regenerated after an edit is applied).
+        /// </summary>
+        public void Clear()
+        {
+            ClearMarkers();
+        }
+
         public void Dispose()
         {
             ClearMarkers();

--- a/src/Forms/FindMethodForm.Designer.cs
+++ b/src/Forms/FindMethodForm.Designer.cs
@@ -1,0 +1,165 @@
+namespace Oxide.Patcher
+{
+    partial class FindMethodForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.searchpanel = new System.Windows.Forms.Panel();
+            this.searchbox = new System.Windows.Forms.TextBox();
+            this.searchlabel = new System.Windows.Forms.Label();
+            this.methodtree = new System.Windows.Forms.TreeView();
+            this.statuslabel = new System.Windows.Forms.Label();
+            this.buttonpanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.cancelbutton = new System.Windows.Forms.Button();
+            this.okbutton = new System.Windows.Forms.Button();
+            this.searchpanel.SuspendLayout();
+            this.buttonpanel.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // searchpanel
+            //
+            this.searchpanel.Controls.Add(this.searchbox);
+            this.searchpanel.Controls.Add(this.searchlabel);
+            this.searchpanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.searchpanel.Location = new System.Drawing.Point(0, 0);
+            this.searchpanel.Name = "searchpanel";
+            this.searchpanel.Padding = new System.Windows.Forms.Padding(8, 8, 8, 4);
+            this.searchpanel.Size = new System.Drawing.Size(620, 40);
+            this.searchpanel.TabIndex = 0;
+            //
+            // searchlabel
+            //
+            this.searchlabel.AutoSize = true;
+            this.searchlabel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.searchlabel.Location = new System.Drawing.Point(8, 8);
+            this.searchlabel.Name = "searchlabel";
+            this.searchlabel.Size = new System.Drawing.Size(46, 28);
+            this.searchlabel.TabIndex = 0;
+            this.searchlabel.Text = "Search:";
+            this.searchlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
+            // searchbox
+            //
+            this.searchbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.searchbox.Location = new System.Drawing.Point(54, 8);
+            this.searchbox.Name = "searchbox";
+            this.searchbox.Size = new System.Drawing.Size(558, 20);
+            this.searchbox.TabIndex = 1;
+            this.searchbox.TextChanged += new System.EventHandler(this.searchbox_TextChanged);
+            //
+            // methodtree
+            //
+            this.methodtree.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.methodtree.HideSelection = false;
+            this.methodtree.Location = new System.Drawing.Point(0, 40);
+            this.methodtree.Name = "methodtree";
+            this.methodtree.Size = new System.Drawing.Size(620, 434);
+            this.methodtree.TabIndex = 1;
+            this.methodtree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.methodtree_BeforeExpand);
+            this.methodtree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.methodtree_AfterSelect);
+            this.methodtree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.methodtree_NodeMouseDoubleClick);
+            //
+            // statuslabel
+            //
+            this.statuslabel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.statuslabel.Location = new System.Drawing.Point(0, 474);
+            this.statuslabel.Name = "statuslabel";
+            this.statuslabel.Padding = new System.Windows.Forms.Padding(8, 0, 8, 0);
+            this.statuslabel.Size = new System.Drawing.Size(620, 22);
+            this.statuslabel.TabIndex = 2;
+            this.statuslabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
+            // buttonpanel
+            //
+            this.buttonpanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.buttonpanel.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.buttonpanel.Location = new System.Drawing.Point(0, 496);
+            this.buttonpanel.Name = "buttonpanel";
+            this.buttonpanel.Padding = new System.Windows.Forms.Padding(8);
+            this.buttonpanel.Size = new System.Drawing.Size(620, 42);
+            this.buttonpanel.TabIndex = 3;
+            //
+            // cancelbutton
+            //
+            this.cancelbutton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelbutton.Location = new System.Drawing.Point(533, 8);
+            this.cancelbutton.Name = "cancelbutton";
+            this.cancelbutton.Size = new System.Drawing.Size(79, 26);
+            this.cancelbutton.TabIndex = 0;
+            this.cancelbutton.Text = "Cancel";
+            this.cancelbutton.UseVisualStyleBackColor = true;
+            this.buttonpanel.Controls.Add(this.cancelbutton);
+            //
+            // okbutton
+            //
+            this.okbutton.Enabled = false;
+            this.okbutton.Location = new System.Drawing.Point(448, 8);
+            this.okbutton.Name = "okbutton";
+            this.okbutton.Size = new System.Drawing.Size(79, 26);
+            this.okbutton.TabIndex = 1;
+            this.okbutton.Text = "Select";
+            this.okbutton.UseVisualStyleBackColor = true;
+            this.okbutton.Click += new System.EventHandler(this.okbutton_Click);
+            this.buttonpanel.Controls.Add(this.okbutton);
+            //
+            // FindMethodForm
+            //
+            this.AcceptButton = this.okbutton;
+            this.CancelButton = this.cancelbutton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(620, 538);
+            this.Controls.Add(this.methodtree);
+            this.Controls.Add(this.statuslabel);
+            this.Controls.Add(this.buttonpanel);
+            this.Controls.Add(this.searchpanel);
+            this.MinimizeBox = false;
+            this.MaximizeBox = false;
+            this.ShowIcon = false;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            this.MinimumSize = new System.Drawing.Size(420, 320);
+            this.Name = "FindMethodForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Find Method";
+            this.searchpanel.ResumeLayout(false);
+            this.searchpanel.PerformLayout();
+            this.buttonpanel.ResumeLayout(false);
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel searchpanel;
+        private System.Windows.Forms.TextBox searchbox;
+        private System.Windows.Forms.Label searchlabel;
+        private System.Windows.Forms.TreeView methodtree;
+        private System.Windows.Forms.Label statuslabel;
+        private System.Windows.Forms.FlowLayoutPanel buttonpanel;
+        private System.Windows.Forms.Button okbutton;
+        private System.Windows.Forms.Button cancelbutton;
+    }
+}

--- a/src/Forms/FindMethodForm.cs
+++ b/src/Forms/FindMethodForm.cs
@@ -1,0 +1,250 @@
+using Mono.Cecil;
+using Oxide.Patcher.Common;
+using Oxide.Patcher.Hooks;
+using Oxide.Patcher.Patching;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Oxide.Patcher
+{
+    /// <summary>
+    /// Dialog that lets the user browse every type and method across the project's
+    /// assemblies (or search for one by partial name) and picks the details needed
+    /// to fill in a hook: assembly, type name, signature, and MSIL hash.
+    /// </summary>
+    public partial class FindMethodForm : Form
+    {
+        private readonly Project _project;
+        private readonly AssemblyLoader _loader;
+        private readonly Dictionary<string, List<TypeDefinition>> _typesByAssembly = new Dictionary<string, List<TypeDefinition>>();
+
+        private int _searchGeneration;
+
+        /// <summary>Gets the assembly name of the selected method once the dialog closes with DialogResult.OK</summary>
+        public string ResultAssemblyName { get; private set; }
+
+        /// <summary>Gets the fully qualified declaring type name of the selected method</summary>
+        public string ResultTypeName { get; private set; }
+
+        /// <summary>Gets the signature of the selected method</summary>
+        public MethodSignature ResultSignature { get; private set; }
+
+        /// <summary>Gets the MSIL hash of the selected method's body, if it has one</summary>
+        public string ResultMsilHash { get; private set; }
+
+        public FindMethodForm(Project project)
+        {
+            InitializeComponent();
+
+            _project = project;
+            _loader = new AssemblyLoader(project, string.Empty, deferLoading: true);
+
+            PopulateAssemblyNodes();
+        }
+
+        private void PopulateAssemblyNodes()
+        {
+            methodtree.BeginUpdate();
+            methodtree.Nodes.Clear();
+
+            foreach (Manifest manifest in _project.Manifests)
+            {
+                AssemblyDefinition assembly = _loader.LoadAssembly(manifest.AssemblyName);
+                if (assembly == null)
+                {
+                    continue;
+                }
+
+                List<TypeDefinition> types = assembly.Modules.SelectMany(m => m.GetTypes())
+                                                              .Where(t => t.HasMethods)
+                                                              .OrderBy(t => t.FullName)
+                                                              .ToList();
+
+                _typesByAssembly[manifest.AssemblyName] = types;
+
+                TreeNode assemblyNode = new TreeNode(manifest.AssemblyName)
+                {
+                    Tag = manifest.AssemblyName
+                };
+                assemblyNode.Nodes.Add(new TreeNode("..."));
+                methodtree.Nodes.Add(assemblyNode);
+            }
+
+            methodtree.EndUpdate();
+
+            statuslabel.Text = _typesByAssembly.Count > 0
+                ? "Expand an assembly to browse its types, or type above to search by name."
+                : "No assemblies are loaded in this project.";
+        }
+
+        private void methodtree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
+        {
+            TreeNode node = e.Node;
+
+            if (node.Tag is string assemblyName && node.Nodes.Count == 1 && node.Nodes[0].Text == "...")
+            {
+                PopulateTypeNodes(node, assemblyName);
+            }
+            else if (node.Tag is TypeDefinition type && node.Nodes.Count == 1 && node.Nodes[0].Text == "...")
+            {
+                PopulateMethodNodes(node, type);
+            }
+        }
+
+        private void PopulateTypeNodes(TreeNode assemblyNode, string assemblyName)
+        {
+            assemblyNode.Nodes.Clear();
+
+            if (!_typesByAssembly.TryGetValue(assemblyName, out List<TypeDefinition> types))
+            {
+                return;
+            }
+
+            foreach (TypeDefinition type in types)
+            {
+                TreeNode typeNode = new TreeNode(type.FullName) { Tag = type };
+                typeNode.Nodes.Add(new TreeNode("..."));
+                assemblyNode.Nodes.Add(typeNode);
+            }
+        }
+
+        private void PopulateMethodNodes(TreeNode typeNode, TypeDefinition type)
+        {
+            typeNode.Nodes.Clear();
+
+            foreach (MethodDefinition method in type.Methods.OrderBy(m => m.Name))
+            {
+                TreeNode methodNode = new TreeNode(Utility.GetMethodDeclaration(method)) { Tag = method };
+                typeNode.Nodes.Add(methodNode);
+            }
+
+            if (typeNode.Nodes.Count == 0)
+            {
+                typeNode.Nodes.Add(new TreeNode("(no methods)"));
+            }
+        }
+
+        private void methodtree_AfterSelect(object sender, TreeViewEventArgs e)
+        {
+            okbutton.Enabled = e.Node?.Tag is MethodDefinition;
+        }
+
+        private void methodtree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        {
+            if (e.Node?.Tag is MethodDefinition)
+            {
+                methodtree.SelectedNode = e.Node;
+                AcceptSelection();
+            }
+        }
+
+        private async void searchbox_TextChanged(object sender, EventArgs e)
+        {
+            string query = searchbox.Text.Trim();
+            int generation = ++_searchGeneration;
+
+            if (query.Length == 0)
+            {
+                PopulateAssemblyNodes();
+                return;
+            }
+
+            if (query.Length < 2)
+            {
+                statuslabel.Text = "Keep typing to search...";
+                return;
+            }
+
+            statuslabel.Text = "Searching...";
+
+            List<TreeNode> results = await System.Threading.Tasks.Task.Run(() => Search(query));
+
+            if (generation != _searchGeneration)
+            {
+                // A newer search has since started; discard these results
+                return;
+            }
+
+            methodtree.BeginUpdate();
+            methodtree.Nodes.Clear();
+            methodtree.Nodes.AddRange(results.ToArray());
+            methodtree.EndUpdate();
+
+            statuslabel.Text = results.Count > 0
+                ? $"{results.Count} matching type{(results.Count == 1 ? string.Empty : "s")} found."
+                : "No matches found.";
+        }
+
+        private List<TreeNode> Search(string query)
+        {
+            List<TreeNode> results = new List<TreeNode>();
+
+            foreach (KeyValuePair<string, List<TypeDefinition>> pair in _typesByAssembly)
+            {
+                foreach (TypeDefinition type in pair.Value)
+                {
+                    bool typeMatches = type.FullName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
+
+                    List<MethodDefinition> matchingMethods = type.Methods
+                        .Where(m => typeMatches || m.Name.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0)
+                        .OrderBy(m => m.Name)
+                        .ToList();
+
+                    if (matchingMethods.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    TreeNode typeNode = new TreeNode($"{pair.Key} :: {type.FullName}") { Tag = type };
+                    foreach (MethodDefinition method in matchingMethods)
+                    {
+                        typeNode.Nodes.Add(new TreeNode(Utility.GetMethodDeclaration(method)) { Tag = method });
+                    }
+
+                    typeNode.Expand();
+                    results.Add(typeNode);
+
+                    if (results.Count >= 200)
+                    {
+                        return results;
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        private void okbutton_Click(object sender, EventArgs e)
+        {
+            AcceptSelection();
+        }
+
+        private void AcceptSelection()
+        {
+            if (!(methodtree.SelectedNode?.Tag is MethodDefinition method))
+            {
+                return;
+            }
+
+            string assemblyName = _loader.rassemblydict.TryGetValue(method.Module.Assembly, out string name)
+                ? name
+                : _typesByAssembly.FirstOrDefault(p => p.Value.Contains(method.DeclaringType)).Key;
+
+            if (assemblyName == null)
+            {
+                MessageBox.Show(this, "Could not determine which assembly this method belongs to.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            ResultAssemblyName = assemblyName;
+            ResultTypeName = method.DeclaringType.FullName;
+            ResultSignature = Utility.GetMethodSignature(method);
+            ResultMsilHash = method.Body != null ? new ILWeaver(method.Body).Hash : null;
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/src/Forms/HookDetailsForm.Designer.cs
+++ b/src/Forms/HookDetailsForm.Designer.cs
@@ -1,0 +1,852 @@
+namespace Oxide.Patcher
+{
+    partial class HookDetailsForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.formtabs = new System.Windows.Forms.TabControl();
+            this.generaltab = new System.Windows.Forms.TabPage();
+            this.detailstable = new System.Windows.Forms.TableLayoutPanel();
+            this.hooktypelabel = new System.Windows.Forms.Label();
+            this.hooktypedropdown = new System.Windows.Forms.ComboBox();
+            this.categorylabel = new System.Windows.Forms.Label();
+            this.categorytextbox = new System.Windows.Forms.TextBox();
+            this.namelabel = new System.Windows.Forms.Label();
+            this.nametextbox = new System.Windows.Forms.TextBox();
+            this.hooknamelabel = new System.Windows.Forms.Label();
+            this.hooknametextbox = new System.Windows.Forms.TextBox();
+            this.hookdescriptionlabel = new System.Windows.Forms.Label();
+            this.hookdescriptiontextbox = new System.Windows.Forms.TextBox();
+            this.assemblylabel = new System.Windows.Forms.Label();
+            this.assemblydropdown = new System.Windows.Forms.ComboBox();
+            this.typenamelabel = new System.Windows.Forms.Label();
+            this.typenametextbox = new System.Windows.Forms.TextBox();
+            this.exposurelabel = new System.Windows.Forms.Label();
+            this.exposuredropdown = new System.Windows.Forms.ComboBox();
+            this.returntypelabel = new System.Windows.Forms.Label();
+            this.returntypetextbox = new System.Windows.Forms.TextBox();
+            this.methodnamelabel = new System.Windows.Forms.Label();
+            this.methodnametextbox = new System.Windows.Forms.TextBox();
+            this.parameterslabel = new System.Windows.Forms.Label();
+            this.parameterstextbox = new System.Windows.Forms.TextBox();
+            this.msilhashlabel = new System.Windows.Forms.Label();
+            this.msilhashtextbox = new System.Windows.Forms.TextBox();
+            this.typesettingstab = new System.Windows.Forms.TabPage();
+            this.typesettingspanel = new System.Windows.Forms.Panel();
+            this.simplesettingspanel = new System.Windows.Forms.Panel();
+            this.simpletable = new System.Windows.Forms.TableLayoutPanel();
+            this.simpleinjectionindexlabel = new System.Windows.Forms.Label();
+            this.simpleinjectionindex = new System.Windows.Forms.NumericUpDown();
+            this.simplereturnbehaviorlabel = new System.Windows.Forms.Label();
+            this.simplereturnbehavior = new System.Windows.Forms.ComboBox();
+            this.simpleargumentbehaviorlabel = new System.Windows.Forms.Label();
+            this.simpleargumentbehavior = new System.Windows.Forms.ComboBox();
+            this.simpleargumentstringlabel = new System.Windows.Forms.Label();
+            this.simpleargumentstring = new System.Windows.Forms.TextBox();
+            this.simpledeprecatedlabel = new System.Windows.Forms.Label();
+            this.simpledeprecatedcheckbox = new System.Windows.Forms.CheckBox();
+            this.simplereplacementhooklabel = new System.Windows.Forms.Label();
+            this.simplereplacementhooktextbox = new System.Windows.Forms.TextBox();
+            this.simpleremovaldatelabel = new System.Windows.Forms.Label();
+            this.simpleremovaldatepicker = new System.Windows.Forms.DateTimePicker();
+            this.initoxidesettingspanel = new System.Windows.Forms.Panel();
+            this.initoxidetable = new System.Windows.Forms.TableLayoutPanel();
+            this.initoxideinjectionindexlabel = new System.Windows.Forms.Label();
+            this.initoxideinjectionindex = new System.Windows.Forms.NumericUpDown();
+            this.modifysettingspanel = new System.Windows.Forms.Panel();
+            this.modifytable = new System.Windows.Forms.TableLayoutPanel();
+            this.modifyinjectionindexlabel = new System.Windows.Forms.Label();
+            this.modifyinjectionindex = new System.Windows.Forms.NumericUpDown();
+            this.modifyremovecountlabel = new System.Windows.Forms.Label();
+            this.modifyremovecount = new System.Windows.Forms.NumericUpDown();
+            this.modifynotelabel = new System.Windows.Forms.Label();
+            this.buttonpanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.okbutton = new System.Windows.Forms.Button();
+            this.cancelbutton = new System.Windows.Forms.Button();
+            this.findmethodbutton = new System.Windows.Forms.Button();
+            this.formtabs.SuspendLayout();
+            this.generaltab.SuspendLayout();
+            this.detailstable.SuspendLayout();
+            this.typesettingstab.SuspendLayout();
+            this.typesettingspanel.SuspendLayout();
+            this.simplesettingspanel.SuspendLayout();
+            this.simpletable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.simpleinjectionindex)).BeginInit();
+            this.initoxidesettingspanel.SuspendLayout();
+            this.initoxidetable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.initoxideinjectionindex)).BeginInit();
+            this.modifysettingspanel.SuspendLayout();
+            this.modifytable.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.modifyinjectionindex)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.modifyremovecount)).BeginInit();
+            this.buttonpanel.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // formtabs
+            //
+            this.formtabs.Controls.Add(this.generaltab);
+            this.formtabs.Controls.Add(this.typesettingstab);
+            this.formtabs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.formtabs.Location = new System.Drawing.Point(0, 0);
+            this.formtabs.Name = "formtabs";
+            this.formtabs.SelectedIndex = 0;
+            this.formtabs.Size = new System.Drawing.Size(524, 429);
+            this.formtabs.TabIndex = 0;
+            //
+            // generaltab
+            //
+            this.generaltab.Controls.Add(this.detailstable);
+            this.generaltab.Location = new System.Drawing.Point(4, 22);
+            this.generaltab.Name = "generaltab";
+            this.generaltab.Padding = new System.Windows.Forms.Padding(3);
+            this.generaltab.Size = new System.Drawing.Size(516, 403);
+            this.generaltab.TabIndex = 0;
+            this.generaltab.Text = "General";
+            this.generaltab.UseVisualStyleBackColor = true;
+            //
+            // detailstable
+            //
+            this.detailstable.ColumnCount = 2;
+            this.detailstable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.detailstable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.detailstable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.detailstable.Location = new System.Drawing.Point(3, 3);
+            this.detailstable.Name = "detailstable";
+            this.detailstable.Padding = new System.Windows.Forms.Padding(8);
+            this.detailstable.RowCount = 13;
+            for (int i = 0; i < 12; i++)
+            {
+                this.detailstable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            }
+            this.detailstable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.detailstable.Size = new System.Drawing.Size(510, 397);
+            this.detailstable.TabIndex = 0;
+            //
+            // hooktypelabel
+            //
+            this.hooktypelabel.AutoSize = true;
+            this.hooktypelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hooktypelabel.Location = new System.Drawing.Point(11, 8);
+            this.hooktypelabel.Name = "hooktypelabel";
+            this.hooktypelabel.Size = new System.Drawing.Size(122, 23);
+            this.hooktypelabel.TabIndex = 0;
+            this.hooktypelabel.Text = "Hook Type:";
+            this.hooktypelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.hooktypelabel, 0, 0);
+            //
+            // hooktypedropdown
+            //
+            this.hooktypedropdown.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hooktypedropdown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.hooktypedropdown.Location = new System.Drawing.Point(141, 11);
+            this.hooktypedropdown.Name = "hooktypedropdown";
+            this.hooktypedropdown.Size = new System.Drawing.Size(358, 21);
+            this.hooktypedropdown.TabIndex = 1;
+            this.hooktypedropdown.SelectedIndexChanged += new System.EventHandler(this.hooktypedropdown_SelectedIndexChanged);
+            this.detailstable.Controls.Add(this.hooktypedropdown, 1, 0);
+            //
+            // categorylabel
+            //
+            this.categorylabel.AutoSize = true;
+            this.categorylabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.categorylabel.Name = "categorylabel";
+            this.categorylabel.Size = new System.Drawing.Size(122, 23);
+            this.categorylabel.TabIndex = 2;
+            this.categorylabel.Text = "Category:";
+            this.categorylabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.categorylabel, 0, 1);
+            //
+            // categorytextbox
+            //
+            this.categorytextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.categorytextbox.Name = "categorytextbox";
+            this.categorytextbox.Size = new System.Drawing.Size(358, 20);
+            this.categorytextbox.TabIndex = 3;
+            this.detailstable.Controls.Add(this.categorytextbox, 1, 1);
+            //
+            // namelabel
+            //
+            this.namelabel.AutoSize = true;
+            this.namelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.namelabel.Name = "namelabel";
+            this.namelabel.Size = new System.Drawing.Size(122, 23);
+            this.namelabel.TabIndex = 4;
+            this.namelabel.Text = "Name:";
+            this.namelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.namelabel, 0, 2);
+            //
+            // nametextbox
+            //
+            this.nametextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.nametextbox.Name = "nametextbox";
+            this.nametextbox.Size = new System.Drawing.Size(358, 20);
+            this.nametextbox.TabIndex = 5;
+            this.detailstable.Controls.Add(this.nametextbox, 1, 2);
+            //
+            // hooknamelabel
+            //
+            this.hooknamelabel.AutoSize = true;
+            this.hooknamelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hooknamelabel.Name = "hooknamelabel";
+            this.hooknamelabel.Size = new System.Drawing.Size(122, 23);
+            this.hooknamelabel.TabIndex = 6;
+            this.hooknamelabel.Text = "Oxide Hook Name:";
+            this.hooknamelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.hooknamelabel, 0, 3);
+            //
+            // hooknametextbox
+            //
+            this.hooknametextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hooknametextbox.Name = "hooknametextbox";
+            this.hooknametextbox.Size = new System.Drawing.Size(358, 20);
+            this.hooknametextbox.TabIndex = 7;
+            this.detailstable.Controls.Add(this.hooknametextbox, 1, 3);
+            //
+            // hookdescriptionlabel
+            //
+            this.hookdescriptionlabel.AutoSize = true;
+            this.hookdescriptionlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hookdescriptionlabel.Name = "hookdescriptionlabel";
+            this.hookdescriptionlabel.Size = new System.Drawing.Size(122, 44);
+            this.hookdescriptionlabel.TabIndex = 8;
+            this.hookdescriptionlabel.Text = "Hook Description:";
+            this.hookdescriptionlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.hookdescriptionlabel, 0, 4);
+            //
+            // hookdescriptiontextbox
+            //
+            this.hookdescriptiontextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hookdescriptiontextbox.MaxLength = 255;
+            this.hookdescriptiontextbox.Multiline = true;
+            this.hookdescriptiontextbox.Name = "hookdescriptiontextbox";
+            this.hookdescriptiontextbox.Size = new System.Drawing.Size(358, 44);
+            this.hookdescriptiontextbox.TabIndex = 9;
+            this.detailstable.Controls.Add(this.hookdescriptiontextbox, 1, 4);
+            //
+            // assemblylabel
+            //
+            this.assemblylabel.AutoSize = true;
+            this.assemblylabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.assemblylabel.Name = "assemblylabel";
+            this.assemblylabel.Size = new System.Drawing.Size(122, 23);
+            this.assemblylabel.TabIndex = 10;
+            this.assemblylabel.Text = "Assembly:";
+            this.assemblylabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.assemblylabel, 0, 5);
+            //
+            // assemblydropdown
+            //
+            this.assemblydropdown.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.assemblydropdown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.assemblydropdown.Name = "assemblydropdown";
+            this.assemblydropdown.Size = new System.Drawing.Size(358, 21);
+            this.assemblydropdown.TabIndex = 11;
+            this.detailstable.Controls.Add(this.assemblydropdown, 1, 5);
+            //
+            // typenamelabel
+            //
+            this.typenamelabel.AutoSize = true;
+            this.typenamelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.typenamelabel.Name = "typenamelabel";
+            this.typenamelabel.Size = new System.Drawing.Size(122, 23);
+            this.typenamelabel.TabIndex = 12;
+            this.typenamelabel.Text = "Full Type Name:";
+            this.typenamelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.typenamelabel, 0, 6);
+            //
+            // typenametextbox
+            //
+            this.typenametextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.typenametextbox.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.typenametextbox.Name = "typenametextbox";
+            this.typenametextbox.Size = new System.Drawing.Size(358, 20);
+            this.typenametextbox.TabIndex = 13;
+            this.detailstable.Controls.Add(this.typenametextbox, 1, 6);
+            //
+            // exposurelabel
+            //
+            this.exposurelabel.AutoSize = true;
+            this.exposurelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.exposurelabel.Name = "exposurelabel";
+            this.exposurelabel.Size = new System.Drawing.Size(122, 23);
+            this.exposurelabel.TabIndex = 14;
+            this.exposurelabel.Text = "Method Exposure:";
+            this.exposurelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.exposurelabel, 0, 7);
+            //
+            // exposuredropdown
+            //
+            this.exposuredropdown.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.exposuredropdown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.exposuredropdown.Name = "exposuredropdown";
+            this.exposuredropdown.Size = new System.Drawing.Size(358, 21);
+            this.exposuredropdown.TabIndex = 15;
+            this.detailstable.Controls.Add(this.exposuredropdown, 1, 7);
+            //
+            // returntypelabel
+            //
+            this.returntypelabel.AutoSize = true;
+            this.returntypelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.returntypelabel.Name = "returntypelabel";
+            this.returntypelabel.Size = new System.Drawing.Size(122, 23);
+            this.returntypelabel.TabIndex = 16;
+            this.returntypelabel.Text = "Return Type:";
+            this.returntypelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.returntypelabel, 0, 8);
+            //
+            // returntypetextbox
+            //
+            this.returntypetextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.returntypetextbox.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.returntypetextbox.Name = "returntypetextbox";
+            this.returntypetextbox.Size = new System.Drawing.Size(358, 20);
+            this.returntypetextbox.TabIndex = 17;
+            this.detailstable.Controls.Add(this.returntypetextbox, 1, 8);
+            //
+            // methodnamelabel
+            //
+            this.methodnamelabel.AutoSize = true;
+            this.methodnamelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.methodnamelabel.Name = "methodnamelabel";
+            this.methodnamelabel.Size = new System.Drawing.Size(122, 23);
+            this.methodnamelabel.TabIndex = 18;
+            this.methodnamelabel.Text = "Method Name:";
+            this.methodnamelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.methodnamelabel, 0, 9);
+            //
+            // methodnametextbox
+            //
+            this.methodnametextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.methodnametextbox.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.methodnametextbox.Name = "methodnametextbox";
+            this.methodnametextbox.Size = new System.Drawing.Size(358, 20);
+            this.methodnametextbox.TabIndex = 19;
+            this.detailstable.Controls.Add(this.methodnametextbox, 1, 9);
+            //
+            // parameterslabel
+            //
+            this.parameterslabel.AutoSize = true;
+            this.parameterslabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.parameterslabel.Name = "parameterslabel";
+            this.parameterslabel.Size = new System.Drawing.Size(122, 23);
+            this.parameterslabel.TabIndex = 20;
+            this.parameterslabel.Text = "Parameters (CSV):";
+            this.parameterslabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.parameterslabel, 0, 10);
+            //
+            // parameterstextbox
+            //
+            this.parameterstextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.parameterstextbox.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.parameterstextbox.Name = "parameterstextbox";
+            this.parameterstextbox.Size = new System.Drawing.Size(358, 20);
+            this.parameterstextbox.TabIndex = 21;
+            this.detailstable.Controls.Add(this.parameterstextbox, 1, 10);
+            //
+            // msilhashlabel
+            //
+            this.msilhashlabel.AutoSize = true;
+            this.msilhashlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.msilhashlabel.Name = "msilhashlabel";
+            this.msilhashlabel.Size = new System.Drawing.Size(122, 23);
+            this.msilhashlabel.TabIndex = 22;
+            this.msilhashlabel.Text = "MSIL Hash:";
+            this.msilhashlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.detailstable.Controls.Add(this.msilhashlabel, 0, 11);
+            //
+            // msilhashtextbox
+            //
+            this.msilhashtextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.msilhashtextbox.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.msilhashtextbox.Name = "msilhashtextbox";
+            this.msilhashtextbox.Size = new System.Drawing.Size(358, 20);
+            this.msilhashtextbox.TabIndex = 23;
+            this.detailstable.Controls.Add(this.msilhashtextbox, 1, 11);
+            //
+            // typesettingstab
+            //
+            this.typesettingstab.Controls.Add(this.typesettingspanel);
+            this.typesettingstab.Location = new System.Drawing.Point(4, 22);
+            this.typesettingstab.Name = "typesettingstab";
+            this.typesettingstab.Padding = new System.Windows.Forms.Padding(3);
+            this.typesettingstab.Size = new System.Drawing.Size(516, 403);
+            this.typesettingstab.TabIndex = 1;
+            this.typesettingstab.Text = "Type Settings";
+            this.typesettingstab.UseVisualStyleBackColor = true;
+            //
+            // typesettingspanel
+            //
+            this.typesettingspanel.Controls.Add(this.simplesettingspanel);
+            this.typesettingspanel.Controls.Add(this.initoxidesettingspanel);
+            this.typesettingspanel.Controls.Add(this.modifysettingspanel);
+            this.typesettingspanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.typesettingspanel.Location = new System.Drawing.Point(3, 3);
+            this.typesettingspanel.Name = "typesettingspanel";
+            this.typesettingspanel.Size = new System.Drawing.Size(510, 397);
+            this.typesettingspanel.TabIndex = 0;
+            //
+            // simplesettingspanel
+            //
+            this.simplesettingspanel.Controls.Add(this.simpletable);
+            this.simplesettingspanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simplesettingspanel.Location = new System.Drawing.Point(0, 0);
+            this.simplesettingspanel.Name = "simplesettingspanel";
+            this.simplesettingspanel.Size = new System.Drawing.Size(510, 397);
+            this.simplesettingspanel.TabIndex = 0;
+            //
+            // simpletable
+            //
+            this.simpletable.ColumnCount = 2;
+            this.simpletable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.simpletable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.simpletable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpletable.Location = new System.Drawing.Point(0, 0);
+            this.simpletable.Name = "simpletable";
+            this.simpletable.Padding = new System.Windows.Forms.Padding(8);
+            this.simpletable.RowCount = 8;
+            for (int i = 0; i < 7; i++)
+            {
+                this.simpletable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            }
+            this.simpletable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.simpletable.Size = new System.Drawing.Size(510, 397);
+            this.simpletable.TabIndex = 0;
+            //
+            // simpleinjectionindexlabel
+            //
+            this.simpleinjectionindexlabel.AutoSize = true;
+            this.simpleinjectionindexlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleinjectionindexlabel.Location = new System.Drawing.Point(11, 8);
+            this.simpleinjectionindexlabel.Name = "simpleinjectionindexlabel";
+            this.simpleinjectionindexlabel.Size = new System.Drawing.Size(122, 23);
+            this.simpleinjectionindexlabel.TabIndex = 0;
+            this.simpleinjectionindexlabel.Text = "Injection Index:";
+            this.simpleinjectionindexlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simpleinjectionindexlabel, 0, 0);
+            //
+            // simpleinjectionindex
+            //
+            this.simpleinjectionindex.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleinjectionindex.Location = new System.Drawing.Point(141, 11);
+            this.simpleinjectionindex.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            this.simpleinjectionindex.Name = "simpleinjectionindex";
+            this.simpleinjectionindex.Size = new System.Drawing.Size(358, 20);
+            this.simpleinjectionindex.TabIndex = 1;
+            this.simpletable.Controls.Add(this.simpleinjectionindex, 1, 0);
+            //
+            // simplereturnbehaviorlabel
+            //
+            this.simplereturnbehaviorlabel.AutoSize = true;
+            this.simplereturnbehaviorlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simplereturnbehaviorlabel.Name = "simplereturnbehaviorlabel";
+            this.simplereturnbehaviorlabel.Size = new System.Drawing.Size(122, 23);
+            this.simplereturnbehaviorlabel.TabIndex = 2;
+            this.simplereturnbehaviorlabel.Text = "Return Behavior:";
+            this.simplereturnbehaviorlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simplereturnbehaviorlabel, 0, 1);
+            //
+            // simplereturnbehavior
+            //
+            this.simplereturnbehavior.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simplereturnbehavior.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.simplereturnbehavior.Name = "simplereturnbehavior";
+            this.simplereturnbehavior.Size = new System.Drawing.Size(358, 21);
+            this.simplereturnbehavior.TabIndex = 3;
+            this.simpletable.Controls.Add(this.simplereturnbehavior, 1, 1);
+            //
+            // simpleargumentbehaviorlabel
+            //
+            this.simpleargumentbehaviorlabel.AutoSize = true;
+            this.simpleargumentbehaviorlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleargumentbehaviorlabel.Name = "simpleargumentbehaviorlabel";
+            this.simpleargumentbehaviorlabel.Size = new System.Drawing.Size(122, 23);
+            this.simpleargumentbehaviorlabel.TabIndex = 4;
+            this.simpleargumentbehaviorlabel.Text = "Argument Behavior:";
+            this.simpleargumentbehaviorlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simpleargumentbehaviorlabel, 0, 2);
+            //
+            // simpleargumentbehavior
+            //
+            this.simpleargumentbehavior.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleargumentbehavior.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.simpleargumentbehavior.Name = "simpleargumentbehavior";
+            this.simpleargumentbehavior.Size = new System.Drawing.Size(358, 21);
+            this.simpleargumentbehavior.TabIndex = 5;
+            this.simpletable.Controls.Add(this.simpleargumentbehavior, 1, 2);
+            //
+            // simpleargumentstringlabel
+            //
+            this.simpleargumentstringlabel.AutoSize = true;
+            this.simpleargumentstringlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleargumentstringlabel.Name = "simpleargumentstringlabel";
+            this.simpleargumentstringlabel.Size = new System.Drawing.Size(122, 23);
+            this.simpleargumentstringlabel.TabIndex = 6;
+            this.simpleargumentstringlabel.Text = "Argument String:";
+            this.simpleargumentstringlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simpleargumentstringlabel, 0, 3);
+            //
+            // simpleargumentstring
+            //
+            this.simpleargumentstring.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleargumentstring.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.simpleargumentstring.Name = "simpleargumentstring";
+            this.simpleargumentstring.Size = new System.Drawing.Size(358, 20);
+            this.simpleargumentstring.TabIndex = 7;
+            this.simpletable.Controls.Add(this.simpleargumentstring, 1, 3);
+            //
+            // simpledeprecatedlabel
+            //
+            this.simpledeprecatedlabel.AutoSize = true;
+            this.simpledeprecatedlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpledeprecatedlabel.Name = "simpledeprecatedlabel";
+            this.simpledeprecatedlabel.Size = new System.Drawing.Size(122, 23);
+            this.simpledeprecatedlabel.TabIndex = 8;
+            this.simpledeprecatedlabel.Text = "Deprecated:";
+            this.simpledeprecatedlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simpledeprecatedlabel, 0, 4);
+            //
+            // simpledeprecatedcheckbox
+            //
+            this.simpledeprecatedcheckbox.AutoSize = true;
+            this.simpledeprecatedcheckbox.Location = new System.Drawing.Point(141, 11);
+            this.simpledeprecatedcheckbox.Name = "simpledeprecatedcheckbox";
+            this.simpledeprecatedcheckbox.Size = new System.Drawing.Size(15, 14);
+            this.simpledeprecatedcheckbox.TabIndex = 9;
+            this.simpledeprecatedcheckbox.UseVisualStyleBackColor = true;
+            this.simpledeprecatedcheckbox.CheckedChanged += new System.EventHandler(this.simpledeprecatedcheckbox_CheckedChanged);
+            this.simpletable.Controls.Add(this.simpledeprecatedcheckbox, 1, 4);
+            //
+            // simplereplacementhooklabel
+            //
+            this.simplereplacementhooklabel.AutoSize = true;
+            this.simplereplacementhooklabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simplereplacementhooklabel.Name = "simplereplacementhooklabel";
+            this.simplereplacementhooklabel.Size = new System.Drawing.Size(122, 23);
+            this.simplereplacementhooklabel.TabIndex = 10;
+            this.simplereplacementhooklabel.Text = "Replacement Hook:";
+            this.simplereplacementhooklabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simplereplacementhooklabel, 0, 5);
+            //
+            // simplereplacementhooktextbox
+            //
+            this.simplereplacementhooktextbox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simplereplacementhooktextbox.Name = "simplereplacementhooktextbox";
+            this.simplereplacementhooktextbox.Size = new System.Drawing.Size(358, 20);
+            this.simplereplacementhooktextbox.TabIndex = 11;
+            this.simpletable.Controls.Add(this.simplereplacementhooktextbox, 1, 5);
+            //
+            // simpleremovaldatelabel
+            //
+            this.simpleremovaldatelabel.AutoSize = true;
+            this.simpleremovaldatelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleremovaldatelabel.Name = "simpleremovaldatelabel";
+            this.simpleremovaldatelabel.Size = new System.Drawing.Size(122, 23);
+            this.simpleremovaldatelabel.TabIndex = 12;
+            this.simpleremovaldatelabel.Text = "Removal Date:";
+            this.simpleremovaldatelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.simpletable.Controls.Add(this.simpleremovaldatelabel, 0, 6);
+            //
+            // simpleremovaldatepicker
+            //
+            this.simpleremovaldatepicker.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.simpleremovaldatepicker.Name = "simpleremovaldatepicker";
+            this.simpleremovaldatepicker.Size = new System.Drawing.Size(358, 20);
+            this.simpleremovaldatepicker.TabIndex = 13;
+            this.simpletable.Controls.Add(this.simpleremovaldatepicker, 1, 6);
+            //
+            // initoxidesettingspanel
+            //
+            this.initoxidesettingspanel.Controls.Add(this.initoxidetable);
+            this.initoxidesettingspanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.initoxidesettingspanel.Location = new System.Drawing.Point(0, 0);
+            this.initoxidesettingspanel.Name = "initoxidesettingspanel";
+            this.initoxidesettingspanel.Size = new System.Drawing.Size(510, 397);
+            this.initoxidesettingspanel.TabIndex = 1;
+            //
+            // initoxidetable
+            //
+            this.initoxidetable.ColumnCount = 2;
+            this.initoxidetable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.initoxidetable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.initoxidetable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.initoxidetable.Location = new System.Drawing.Point(0, 0);
+            this.initoxidetable.Name = "initoxidetable";
+            this.initoxidetable.Padding = new System.Windows.Forms.Padding(8);
+            this.initoxidetable.RowCount = 2;
+            this.initoxidetable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.initoxidetable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.initoxidetable.Size = new System.Drawing.Size(510, 397);
+            this.initoxidetable.TabIndex = 0;
+            //
+            // initoxideinjectionindexlabel
+            //
+            this.initoxideinjectionindexlabel.AutoSize = true;
+            this.initoxideinjectionindexlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.initoxideinjectionindexlabel.Location = new System.Drawing.Point(11, 8);
+            this.initoxideinjectionindexlabel.Name = "initoxideinjectionindexlabel";
+            this.initoxideinjectionindexlabel.Size = new System.Drawing.Size(122, 23);
+            this.initoxideinjectionindexlabel.TabIndex = 0;
+            this.initoxideinjectionindexlabel.Text = "Injection Index:";
+            this.initoxideinjectionindexlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.initoxidetable.Controls.Add(this.initoxideinjectionindexlabel, 0, 0);
+            //
+            // initoxideinjectionindex
+            //
+            this.initoxideinjectionindex.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.initoxideinjectionindex.Location = new System.Drawing.Point(141, 11);
+            this.initoxideinjectionindex.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            this.initoxideinjectionindex.Name = "initoxideinjectionindex";
+            this.initoxideinjectionindex.Size = new System.Drawing.Size(358, 20);
+            this.initoxideinjectionindex.TabIndex = 1;
+            this.initoxidetable.Controls.Add(this.initoxideinjectionindex, 1, 0);
+            //
+            // modifysettingspanel
+            //
+            this.modifysettingspanel.Controls.Add(this.modifytable);
+            this.modifysettingspanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifysettingspanel.Location = new System.Drawing.Point(0, 0);
+            this.modifysettingspanel.Name = "modifysettingspanel";
+            this.modifysettingspanel.Size = new System.Drawing.Size(510, 397);
+            this.modifysettingspanel.TabIndex = 2;
+            //
+            // modifytable
+            //
+            this.modifytable.ColumnCount = 2;
+            this.modifytable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.modifytable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.modifytable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifytable.Location = new System.Drawing.Point(0, 0);
+            this.modifytable.Name = "modifytable";
+            this.modifytable.Padding = new System.Windows.Forms.Padding(8);
+            this.modifytable.RowCount = 4;
+            this.modifytable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.modifytable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.modifytable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.modifytable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.modifytable.Size = new System.Drawing.Size(510, 397);
+            this.modifytable.TabIndex = 0;
+            //
+            // modifyinjectionindexlabel
+            //
+            this.modifyinjectionindexlabel.AutoSize = true;
+            this.modifyinjectionindexlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifyinjectionindexlabel.Location = new System.Drawing.Point(11, 8);
+            this.modifyinjectionindexlabel.Name = "modifyinjectionindexlabel";
+            this.modifyinjectionindexlabel.Size = new System.Drawing.Size(122, 23);
+            this.modifyinjectionindexlabel.TabIndex = 0;
+            this.modifyinjectionindexlabel.Text = "Injection Index:";
+            this.modifyinjectionindexlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.modifytable.Controls.Add(this.modifyinjectionindexlabel, 0, 0);
+            //
+            // modifyinjectionindex
+            //
+            this.modifyinjectionindex.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifyinjectionindex.Location = new System.Drawing.Point(141, 11);
+            this.modifyinjectionindex.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            this.modifyinjectionindex.Name = "modifyinjectionindex";
+            this.modifyinjectionindex.Size = new System.Drawing.Size(358, 20);
+            this.modifyinjectionindex.TabIndex = 1;
+            this.modifytable.Controls.Add(this.modifyinjectionindex, 1, 0);
+            //
+            // modifyremovecountlabel
+            //
+            this.modifyremovecountlabel.AutoSize = true;
+            this.modifyremovecountlabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifyremovecountlabel.Name = "modifyremovecountlabel";
+            this.modifyremovecountlabel.Size = new System.Drawing.Size(122, 23);
+            this.modifyremovecountlabel.TabIndex = 2;
+            this.modifyremovecountlabel.Text = "Remove Count:";
+            this.modifyremovecountlabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.modifytable.Controls.Add(this.modifyremovecountlabel, 0, 1);
+            //
+            // modifyremovecount
+            //
+            this.modifyremovecount.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifyremovecount.Maximum = new decimal(new int[] { 1000000, 0, 0, 0 });
+            this.modifyremovecount.Name = "modifyremovecount";
+            this.modifyremovecount.Size = new System.Drawing.Size(358, 20);
+            this.modifyremovecount.TabIndex = 3;
+            this.modifytable.Controls.Add(this.modifyremovecount, 1, 1);
+            //
+            // modifynotelabel
+            //
+            this.modifynotelabel.AutoSize = false;
+            this.modifynotelabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.modifynotelabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.modifynotelabel.Name = "modifynotelabel";
+            this.modifynotelabel.Size = new System.Drawing.Size(358, 40);
+            this.modifynotelabel.TabIndex = 4;
+            this.modifynotelabel.Text = "This hook type also has a generated instruction list. Save this hook first, the" +
+    "n edit its instructions from the hook\'s own tab.";
+            this.modifytable.Controls.Add(this.modifynotelabel, 1, 2);
+            //
+            // buttonpanel
+            //
+            this.buttonpanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.buttonpanel.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.buttonpanel.Location = new System.Drawing.Point(0, 429);
+            this.buttonpanel.Name = "buttonpanel";
+            this.buttonpanel.Padding = new System.Windows.Forms.Padding(8);
+            this.buttonpanel.Size = new System.Drawing.Size(524, 42);
+            this.buttonpanel.TabIndex = 1;
+            //
+            // cancelbutton
+            //
+            this.cancelbutton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelbutton.Location = new System.Drawing.Point(437, 8);
+            this.cancelbutton.Name = "cancelbutton";
+            this.cancelbutton.Size = new System.Drawing.Size(79, 26);
+            this.cancelbutton.TabIndex = 0;
+            this.cancelbutton.Text = "Cancel";
+            this.cancelbutton.UseVisualStyleBackColor = true;
+            this.buttonpanel.Controls.Add(this.cancelbutton);
+            //
+            // okbutton
+            //
+            this.okbutton.Location = new System.Drawing.Point(352, 8);
+            this.okbutton.Name = "okbutton";
+            this.okbutton.Size = new System.Drawing.Size(79, 26);
+            this.okbutton.TabIndex = 1;
+            this.okbutton.Text = "OK";
+            this.okbutton.UseVisualStyleBackColor = true;
+            this.okbutton.Click += new System.EventHandler(this.okbutton_Click);
+            this.buttonpanel.Controls.Add(this.okbutton);
+            //
+            // findmethodbutton
+            //
+            this.findmethodbutton.Location = new System.Drawing.Point(267, 8);
+            this.findmethodbutton.Name = "findmethodbutton";
+            this.findmethodbutton.Size = new System.Drawing.Size(97, 26);
+            this.findmethodbutton.TabIndex = 2;
+            this.findmethodbutton.Text = "Find Method...";
+            this.findmethodbutton.UseVisualStyleBackColor = true;
+            this.findmethodbutton.Click += new System.EventHandler(this.findmethodbutton_Click);
+            this.buttonpanel.Controls.Add(this.findmethodbutton);
+            //
+            // HookDetailsForm
+            //
+            this.AcceptButton = this.okbutton;
+            this.CancelButton = this.cancelbutton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(524, 471);
+            this.Controls.Add(this.formtabs);
+            this.Controls.Add(this.buttonpanel);
+            this.MinimizeBox = false;
+            this.MaximizeBox = false;
+            this.ShowIcon = false;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Name = "HookDetailsForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Hook Details";
+            this.formtabs.ResumeLayout(false);
+            this.generaltab.ResumeLayout(false);
+            this.detailstable.ResumeLayout(false);
+            this.detailstable.PerformLayout();
+            this.typesettingstab.ResumeLayout(false);
+            this.typesettingspanel.ResumeLayout(false);
+            this.simplesettingspanel.ResumeLayout(false);
+            this.simpletable.ResumeLayout(false);
+            this.simpletable.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.simpleinjectionindex)).EndInit();
+            this.initoxidesettingspanel.ResumeLayout(false);
+            this.initoxidetable.ResumeLayout(false);
+            this.initoxidetable.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.initoxideinjectionindex)).EndInit();
+            this.modifysettingspanel.ResumeLayout(false);
+            this.modifytable.ResumeLayout(false);
+            this.modifytable.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.modifyinjectionindex)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.modifyremovecount)).EndInit();
+            this.buttonpanel.ResumeLayout(false);
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TabControl formtabs;
+        private System.Windows.Forms.TabPage generaltab;
+        private System.Windows.Forms.TableLayoutPanel detailstable;
+        private System.Windows.Forms.Label hooktypelabel;
+        private System.Windows.Forms.ComboBox hooktypedropdown;
+        private System.Windows.Forms.Label categorylabel;
+        private System.Windows.Forms.TextBox categorytextbox;
+        private System.Windows.Forms.Label namelabel;
+        private System.Windows.Forms.TextBox nametextbox;
+        private System.Windows.Forms.Label hooknamelabel;
+        private System.Windows.Forms.TextBox hooknametextbox;
+        private System.Windows.Forms.Label hookdescriptionlabel;
+        private System.Windows.Forms.TextBox hookdescriptiontextbox;
+        private System.Windows.Forms.Label assemblylabel;
+        private System.Windows.Forms.ComboBox assemblydropdown;
+        private System.Windows.Forms.Label typenamelabel;
+        private System.Windows.Forms.TextBox typenametextbox;
+        private System.Windows.Forms.Label exposurelabel;
+        private System.Windows.Forms.ComboBox exposuredropdown;
+        private System.Windows.Forms.Label returntypelabel;
+        private System.Windows.Forms.TextBox returntypetextbox;
+        private System.Windows.Forms.Label methodnamelabel;
+        private System.Windows.Forms.TextBox methodnametextbox;
+        private System.Windows.Forms.Label parameterslabel;
+        private System.Windows.Forms.TextBox parameterstextbox;
+        private System.Windows.Forms.Label msilhashlabel;
+        private System.Windows.Forms.TextBox msilhashtextbox;
+        private System.Windows.Forms.TabPage typesettingstab;
+        private System.Windows.Forms.Panel typesettingspanel;
+        private System.Windows.Forms.Panel simplesettingspanel;
+        private System.Windows.Forms.TableLayoutPanel simpletable;
+        private System.Windows.Forms.Label simpleinjectionindexlabel;
+        private System.Windows.Forms.NumericUpDown simpleinjectionindex;
+        private System.Windows.Forms.Label simplereturnbehaviorlabel;
+        private System.Windows.Forms.ComboBox simplereturnbehavior;
+        private System.Windows.Forms.Label simpleargumentbehaviorlabel;
+        private System.Windows.Forms.ComboBox simpleargumentbehavior;
+        private System.Windows.Forms.Label simpleargumentstringlabel;
+        private System.Windows.Forms.TextBox simpleargumentstring;
+        private System.Windows.Forms.Label simpledeprecatedlabel;
+        private System.Windows.Forms.CheckBox simpledeprecatedcheckbox;
+        private System.Windows.Forms.Label simplereplacementhooklabel;
+        private System.Windows.Forms.TextBox simplereplacementhooktextbox;
+        private System.Windows.Forms.Label simpleremovaldatelabel;
+        private System.Windows.Forms.DateTimePicker simpleremovaldatepicker;
+        private System.Windows.Forms.Panel initoxidesettingspanel;
+        private System.Windows.Forms.TableLayoutPanel initoxidetable;
+        private System.Windows.Forms.Label initoxideinjectionindexlabel;
+        private System.Windows.Forms.NumericUpDown initoxideinjectionindex;
+        private System.Windows.Forms.Panel modifysettingspanel;
+        private System.Windows.Forms.TableLayoutPanel modifytable;
+        private System.Windows.Forms.Label modifyinjectionindexlabel;
+        private System.Windows.Forms.NumericUpDown modifyinjectionindex;
+        private System.Windows.Forms.Label modifyremovecountlabel;
+        private System.Windows.Forms.NumericUpDown modifyremovecount;
+        private System.Windows.Forms.Label modifynotelabel;
+        private System.Windows.Forms.FlowLayoutPanel buttonpanel;
+        private System.Windows.Forms.Button okbutton;
+        private System.Windows.Forms.Button cancelbutton;
+        private System.Windows.Forms.Button findmethodbutton;
+    }
+}

--- a/src/Forms/HookDetailsForm.cs
+++ b/src/Forms/HookDetailsForm.cs
@@ -1,0 +1,403 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+using Oxide.Patcher.Hooks;
+
+namespace Oxide.Patcher
+{
+    /// <summary>
+    /// Dialog used both to create a brand new hook and to edit every detail of an
+    /// existing hook - assembly, type, signature, category, hook type, and every
+    /// type-specific setting - without needing to hand-edit the .opj project file.
+    /// </summary>
+    public partial class HookDetailsForm : Form
+    {
+        private readonly Project _project;
+        private readonly Hook _existingHook;
+
+        /// <summary>
+        /// Gets the hook that was created or updated once the dialog closes with DialogResult.OK.
+        /// In edit mode, this is the same object passed in unless the hook type was changed, in
+        /// which case it is a newly created hook of the new type.
+        /// </summary>
+        public Hook ResultHook { get; private set; }
+
+        /// <summary>
+        /// Creates a dialog for adding a brand new hook
+        /// </summary>
+        /// <param name="project">The current project, used to populate the assembly list</param>
+        /// <param name="categoryHint">The category the new hook should be created in, if any</param>
+        public HookDetailsForm(Project project, string categoryHint = null)
+        {
+            InitializeComponent();
+
+            _project = project;
+            _existingHook = null;
+            Text = "Add New Hook";
+
+            PopulateAssemblies();
+            PopulateExposures();
+            PopulateReturnAndArgumentBehaviors();
+            PopulateHookTypes(null);
+
+            categorytextbox.Text = categoryHint ?? string.Empty;
+            exposuredropdown.SelectedItem = MethodExposure.Public.ToString();
+        }
+
+        /// <summary>
+        /// Creates a dialog for editing every detail of an existing hook, including switching
+        /// it to a different hook type
+        /// </summary>
+        /// <param name="project">The current project, used to populate the assembly list</param>
+        /// <param name="hook">The hook to edit</param>
+        public HookDetailsForm(Project project, Hook hook)
+        {
+            InitializeComponent();
+
+            _project = project;
+            _existingHook = hook ?? throw new ArgumentNullException(nameof(hook));
+            Text = "Edit Hook Details";
+
+            PopulateAssemblies();
+            PopulateExposures();
+            PopulateReturnAndArgumentBehaviors();
+
+            categorytextbox.Text = hook.HookCategory ?? string.Empty;
+            nametextbox.Text = hook.Name;
+            hooknametextbox.Text = hook.HookName;
+            hookdescriptiontextbox.Text = hook.HookDescription;
+            typenametextbox.Text = hook.TypeName;
+            msilhashtextbox.Text = hook.MSILHash;
+
+            if (assemblydropdown.Items.Contains(hook.AssemblyName))
+            {
+                assemblydropdown.SelectedItem = hook.AssemblyName;
+            }
+
+            if (hook.Signature != null)
+            {
+                exposuredropdown.SelectedItem = hook.Signature.Exposure.ToString();
+                returntypetextbox.Text = hook.Signature.ReturnType;
+                methodnametextbox.Text = hook.Signature.Name;
+                parameterstextbox.Text = string.Join(", ", hook.Signature.Parameters);
+            }
+            else
+            {
+                exposuredropdown.SelectedItem = MethodExposure.Public.ToString();
+            }
+
+            // Populated last: selecting the hook's current type fires SelectedIndexChanged,
+            // which loads that type's settings from the hook - so everything else needs to
+            // already be in place first
+            PopulateHookTypes(hook.GetType());
+        }
+
+        private void PopulateHookTypes(Type preselect)
+        {
+            for (int i = 0; i < Hook.HookTypes.Length; i++)
+            {
+                string typeName = Hook.HookTypes[i].GetCustomAttribute<HookType>().Name;
+                hooktypedropdown.Items.Add(typeName);
+
+                bool shouldSelect = preselect != null ? Hook.HookTypes[i] == preselect : Hook.HookTypes[i] == Hook.DefaultHookType;
+                if (shouldSelect)
+                {
+                    hooktypedropdown.SelectedIndex = i;
+                }
+            }
+
+            if (hooktypedropdown.SelectedIndex < 0 && hooktypedropdown.Items.Count > 0)
+            {
+                hooktypedropdown.SelectedIndex = 0;
+            }
+        }
+
+        private void PopulateAssemblies()
+        {
+            foreach (Manifest manifest in _project.Manifests)
+            {
+                assemblydropdown.Items.Add(manifest.AssemblyName);
+            }
+
+            if (assemblydropdown.Items.Count > 0 && assemblydropdown.SelectedIndex < 0)
+            {
+                assemblydropdown.SelectedIndex = 0;
+            }
+        }
+
+        private void PopulateExposures()
+        {
+            foreach (string name in Enum.GetNames(typeof(MethodExposure)))
+            {
+                exposuredropdown.Items.Add(name);
+            }
+        }
+
+        private void PopulateReturnAndArgumentBehaviors()
+        {
+            foreach (ReturnBehavior value in Enum.GetValues(typeof(ReturnBehavior)))
+            {
+                simplereturnbehavior.Items.Add(value);
+            }
+
+            foreach (ArgumentBehavior value in Enum.GetValues(typeof(ArgumentBehavior)))
+            {
+                simpleargumentbehavior.Items.Add(value);
+            }
+        }
+
+        private void hooktypedropdown_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (hooktypedropdown.SelectedIndex < 0)
+            {
+                return;
+            }
+
+            Type hookType = Hook.HookTypes[hooktypedropdown.SelectedIndex];
+            ShowTypeSettingsPanel(hookType);
+
+            if (_existingHook != null && hookType == _existingHook.GetType())
+            {
+                // Selected type matches the hook's actual type - show its real settings
+                LoadTypeSettingsFromHook(_existingHook);
+            }
+            else
+            {
+                // A brand new hook, or switching to a different type - start fresh, since
+                // settings from one hook type don't carry over to another
+                ResetTypeSettingsToDefaults(hookType);
+            }
+        }
+
+        private void ShowTypeSettingsPanel(Type hookType)
+        {
+            simplesettingspanel.Visible = hookType == typeof(Simple);
+            initoxidesettingspanel.Visible = hookType == typeof(InitOxide);
+            modifysettingspanel.Visible = hookType == typeof(Modify);
+        }
+
+        private void LoadTypeSettingsFromHook(Hook hook)
+        {
+            switch (hook)
+            {
+                case Simple simple:
+                    simpleinjectionindex.Value = Math.Max(0, simple.InjectionIndex);
+                    simplereturnbehavior.SelectedIndex = (int)simple.ReturnBehavior;
+                    simpleargumentbehavior.SelectedIndex = (int)simple.ArgumentBehavior;
+                    simpleargumentstring.Text = simple.ArgumentString ?? string.Empty;
+                    simpledeprecatedcheckbox.Checked = simple.Deprecation != null;
+                    simplereplacementhooktextbox.Text = simple.Deprecation?.ReplacementHook ?? string.Empty;
+                    simpleremovaldatepicker.Value = simple.Deprecation?.RemovalDate ?? DateTime.Now.AddDays(60);
+                    break;
+
+                case InitOxide initOxide:
+                    initoxideinjectionindex.Value = Math.Max(0, initOxide.InjectionIndex);
+                    break;
+
+                case Modify modify:
+                    modifyinjectionindex.Value = Math.Max(0, modify.InjectionIndex);
+                    modifyremovecount.Value = Math.Max(0, modify.RemoveCount);
+                    break;
+            }
+        }
+
+        private void ResetTypeSettingsToDefaults(Type hookType)
+        {
+            if (hookType == typeof(Simple))
+            {
+                simpleinjectionindex.Value = 0;
+                simplereturnbehavior.SelectedIndex = (int)ReturnBehavior.Continue;
+                simpleargumentbehavior.SelectedIndex = (int)ArgumentBehavior.None;
+                simpleargumentstring.Text = string.Empty;
+                simpledeprecatedcheckbox.Checked = false;
+                simplereplacementhooktextbox.Text = string.Empty;
+                simpleremovaldatepicker.Value = DateTime.Now.AddDays(60);
+            }
+            else if (hookType == typeof(InitOxide))
+            {
+                initoxideinjectionindex.Value = 0;
+            }
+            else if (hookType == typeof(Modify))
+            {
+                modifyinjectionindex.Value = 0;
+                modifyremovecount.Value = 0;
+            }
+        }
+
+        private void ApplyTypeSettings(Hook hook)
+        {
+            switch (hook)
+            {
+                case Simple simple:
+                    simple.InjectionIndex = (int)simpleinjectionindex.Value;
+                    simple.ReturnBehavior = (ReturnBehavior)simplereturnbehavior.SelectedIndex;
+                    simple.ArgumentBehavior = (ArgumentBehavior)simpleargumentbehavior.SelectedIndex;
+                    simple.ArgumentString = simpleargumentstring.Text;
+                    simple.Deprecation = simpledeprecatedcheckbox.Checked
+                        ? new Simple.DeprecatedStatus
+                        {
+                            ReplacementHook = simplereplacementhooktextbox.Text.Trim(),
+                            RemovalDate = simpleremovaldatepicker.Value
+                        }
+                        : null;
+                    break;
+
+                case InitOxide initOxide:
+                    initOxide.InjectionIndex = (int)initoxideinjectionindex.Value;
+                    break;
+
+                case Modify modify:
+                    modify.InjectionIndex = (int)modifyinjectionindex.Value;
+                    modify.RemoveCount = (int)modifyremovecount.Value;
+                    break;
+            }
+        }
+
+        private void simpledeprecatedcheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            bool isDeprecated = simpledeprecatedcheckbox.Checked;
+
+            simplereplacementhooklabel.Enabled = isDeprecated;
+            simplereplacementhooktextbox.Enabled = isDeprecated;
+            simpleremovaldatelabel.Enabled = isDeprecated;
+            simpleremovaldatepicker.Enabled = isDeprecated;
+
+            if (isDeprecated && simpleremovaldatepicker.Value < DateTime.Now)
+            {
+                simpleremovaldatepicker.Value = DateTime.Now.AddDays(60);
+            }
+        }
+
+        private void findmethodbutton_Click(object sender, EventArgs e)
+        {
+            using (FindMethodForm form = new FindMethodForm(_project))
+            {
+                if (form.ShowDialog(this) != DialogResult.OK)
+                {
+                    return;
+                }
+
+                if (!assemblydropdown.Items.Contains(form.ResultAssemblyName))
+                {
+                    assemblydropdown.Items.Add(form.ResultAssemblyName);
+                }
+                assemblydropdown.SelectedItem = form.ResultAssemblyName;
+
+                typenametextbox.Text = form.ResultTypeName;
+                exposuredropdown.SelectedItem = form.ResultSignature.Exposure.ToString();
+                returntypetextbox.Text = form.ResultSignature.ReturnType;
+                methodnametextbox.Text = form.ResultSignature.Name;
+                parameterstextbox.Text = string.Join(", ", form.ResultSignature.Parameters);
+
+                if (form.ResultMsilHash != null)
+                {
+                    msilhashtextbox.Text = form.ResultMsilHash;
+                }
+
+                if (nametextbox.TextLength == 0)
+                {
+                    nametextbox.Text = form.ResultSignature.Name;
+                }
+
+                if (hooknametextbox.TextLength == 0)
+                {
+                    hooknametextbox.Text = form.ResultSignature.Name;
+                }
+            }
+        }
+
+        private void okbutton_Click(object sender, EventArgs e)
+        {
+            if (nametextbox.TextLength == 0)
+            {
+                MessageBox.Show(this, "Please enter a hook name.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (hooknametextbox.TextLength == 0)
+            {
+                MessageBox.Show(this, "Please enter an Oxide hook name.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (assemblydropdown.SelectedItem == null)
+            {
+                MessageBox.Show(this, "Please select an assembly. If none are listed, add one to the project first.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (typenametextbox.TextLength == 0)
+            {
+                MessageBox.Show(this, "Please enter the fully qualified type name.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (methodnametextbox.TextLength == 0)
+            {
+                MessageBox.Show(this, "Please enter the target method name.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (hooktypedropdown.SelectedIndex < 0)
+            {
+                MessageBox.Show(this, "Please select a hook type.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            Type selectedHookType = Hook.HookTypes[hooktypedropdown.SelectedIndex];
+
+            if (selectedHookType == typeof(Simple) && simpledeprecatedcheckbox.Checked && simplereplacementhooktextbox.TextLength == 0)
+            {
+                MessageBox.Show(this, "Please enter the name of the replacement hook, or uncheck Deprecated.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            MethodExposure exposure = (MethodExposure)Enum.Parse(typeof(MethodExposure), (string)exposuredropdown.SelectedItem);
+
+            string[] parameters = parameterstextbox.Text
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.Trim())
+                .Where(p => p.Length > 0)
+                .ToArray();
+
+            MethodSignature signature = new MethodSignature(exposure, returntypetextbox.Text.Trim(), methodnametextbox.Text.Trim(), parameters);
+
+            Hook hook;
+            if (_existingHook != null && selectedHookType == _existingHook.GetType())
+            {
+                // Same type as before - update the existing hook object in place
+                hook = _existingHook;
+            }
+            else if (_existingHook != null)
+            {
+                // Switched to a different hook type - the object has to be recreated, so
+                // carry over everything that isn't tied to the old type's settings
+                hook = Activator.CreateInstance(selectedHookType) as Hook;
+                hook.Flagged = _existingHook.Flagged;
+                hook.FlagReason = _existingHook.FlagReason;
+                hook.BaseHook = _existingHook.BaseHook;
+                hook.BaseHookName = _existingHook.BaseHookName;
+            }
+            else
+            {
+                hook = Activator.CreateInstance(selectedHookType) as Hook;
+            }
+
+            hook.Name = nametextbox.Text.Trim();
+            hook.HookName = hooknametextbox.Text.Trim();
+            hook.HookDescription = hookdescriptiontextbox.Text;
+            hook.AssemblyName = (string)assemblydropdown.SelectedItem;
+            hook.TypeName = typenametextbox.Text.Trim();
+            hook.Signature = signature;
+            hook.MSILHash = msilhashtextbox.TextLength > 0 ? msilhashtextbox.Text.Trim() : null;
+            hook.HookCategory = categorytextbox.TextLength > 0 ? categorytextbox.Text.Trim() : null;
+
+            ApplyTypeSettings(hook);
+
+            ResultHook = hook;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/src/OpjData/Fields/Field.cs
+++ b/src/OpjData/Fields/Field.cs
@@ -38,6 +38,11 @@ namespace Oxide.Patcher.Fields
         /// </summary>
         public bool Flagged { get; set; }
 
+        /// <summary>
+        /// Gets or sets a short human readable reason this field was flagged, if known
+        /// </summary>
+        public string FlagReason { get; set; }
+
         public Field()
         {
         }

--- a/src/OpjData/Hooks/Hook.cs
+++ b/src/OpjData/Hooks/Hook.cs
@@ -55,6 +55,11 @@ namespace Oxide.Patcher.Hooks
         public bool Flagged { get; set; }
 
         /// <summary>
+        /// Gets or sets a short human readable reason this hook was flagged, if known
+        /// </summary>
+        public string FlagReason { get; set; }
+
+        /// <summary>
         /// Gets or sets the target method signature
         /// </summary>
         public MethodSignature Signature { get; set; }

--- a/src/OpjData/Modifiers/Modifier.cs
+++ b/src/OpjData/Modifiers/Modifier.cs
@@ -44,6 +44,11 @@ namespace Oxide.Patcher.Modifiers
         public bool Flagged { get; set; }
 
         /// <summary>
+        /// Gets or sets a short human readable reason this modifier was flagged, if known
+        /// </summary>
+        public string FlagReason { get; set; }
+
+        /// <summary>
         /// Gets or sets the target signature
         /// </summary>
         public ModifierSignature Signature { get; set; }

--- a/src/PatcherForm.Designer.cs
+++ b/src/PatcherForm.Designer.cs
@@ -46,10 +46,17 @@ namespace Oxide.Patcher
             this.generateDocsButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.patchtool = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+            this.showflaggedbutton = new System.Windows.Forms.ToolStripButton();
             this.mainstatusbar = new System.Windows.Forms.StatusStrip();
             this.statuslabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.splitter = new System.Windows.Forms.SplitContainer();
             this.objectview = new System.Windows.Forms.TreeView();
+            this.flaggedpanel = new System.Windows.Forms.Panel();
+            this.flaggedlistview = new System.Windows.Forms.ListView();
+            this.flaggeditemcolumn = new System.Windows.Forms.ColumnHeader();
+            this.flaggedreasoncolumn = new System.Windows.Forms.ColumnHeader();
+            this.flaggedheaderlabel = new System.Windows.Forms.Label();
             this.imagelist = new System.Windows.Forms.ImageList(this.components);
             this.tabview = new System.Windows.Forms.TabControl();
             this.tabviewcontextmenu = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -72,11 +79,15 @@ namespace Oxide.Patcher
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.FlagCategory = new System.Windows.Forms.ToolStripMenuItem();
             this.UnflagCategory = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.addNewHookToCategoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hookmenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.addNewHookToRootMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.imagelistDragDrop = new System.Windows.Forms.ImageList(this.components);
             this.modifiersMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.flagAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -88,6 +99,7 @@ namespace Oxide.Patcher
             this.splitter.Panel1.SuspendLayout();
             this.splitter.Panel2.SuspendLayout();
             this.splitter.SuspendLayout();
+            this.flaggedpanel.SuspendLayout();
             this.tabviewcontextmenu.SuspendLayout();
             this.unloadedassemblymenu.SuspendLayout();
             this.loadedassemblymenu.SuspendLayout();
@@ -175,7 +187,7 @@ namespace Oxide.Patcher
             //
             this.maintoolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
             {
-                this.newprojecttool, this.openprojecttool, this.generateDocsButton, this.toolStripSeparator3, this.patchtool
+                this.newprojecttool, this.openprojecttool, this.generateDocsButton, this.toolStripSeparator3, this.patchtool, this.toolStripSeparator9, this.showflaggedbutton
             });
             this.maintoolbar.Location = new System.Drawing.Point(0, 24);
             this.maintoolbar.Name = "maintoolbar";
@@ -233,6 +245,22 @@ namespace Oxide.Patcher
             this.patchtool.Size = new System.Drawing.Size(23, 22);
             this.patchtool.Text = "Patch";
             this.patchtool.Click += new System.EventHandler(this.patchtool_Click);
+
+            //
+            // toolStripSeparator9
+            //
+            this.toolStripSeparator9.Name = "toolStripSeparator9";
+            this.toolStripSeparator9.Size = new System.Drawing.Size(6, 25);
+
+            //
+            // showflaggedbutton
+            //
+            this.showflaggedbutton.CheckOnClick = true;
+            this.showflaggedbutton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.showflaggedbutton.Name = "showflaggedbutton";
+            this.showflaggedbutton.Size = new System.Drawing.Size(110, 22);
+            this.showflaggedbutton.Text = "Flagged";
+            this.showflaggedbutton.Click += new System.EventHandler(this.showflaggedbutton_Click);
 
             //
             // mainstatusbar
@@ -294,6 +322,57 @@ namespace Oxide.Patcher
             this.objectview.DragOver += new System.Windows.Forms.DragEventHandler(this.objectview_DragOver);
             this.objectview.DragLeave += new System.EventHandler(this.objectview_DragLeave);
             this.objectview.MouseDown += new System.Windows.Forms.MouseEventHandler(this.objectview_MouseDown);
+
+            //
+            // flaggedpanel
+            //
+            this.flaggedpanel.Controls.Add(this.flaggedlistview);
+            this.flaggedpanel.Controls.Add(this.flaggedheaderlabel);
+            this.flaggedpanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flaggedpanel.Location = new System.Drawing.Point(0, 509);
+            this.flaggedpanel.Name = "flaggedpanel";
+            this.flaggedpanel.Padding = new System.Windows.Forms.Padding(4);
+            this.flaggedpanel.Size = new System.Drawing.Size(1264, 150);
+            this.flaggedpanel.TabIndex = 5;
+            //
+            // flaggedheaderlabel
+            //
+            this.flaggedheaderlabel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.flaggedheaderlabel.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            this.flaggedheaderlabel.Location = new System.Drawing.Point(4, 4);
+            this.flaggedheaderlabel.Name = "flaggedheaderlabel";
+            this.flaggedheaderlabel.Padding = new System.Windows.Forms.Padding(2);
+            this.flaggedheaderlabel.Size = new System.Drawing.Size(1256, 20);
+            this.flaggedheaderlabel.TabIndex = 1;
+            this.flaggedheaderlabel.Text = "Flagged Items";
+            //
+            // flaggedlistview
+            //
+            this.flaggedlistview.Columns.AddRange(new System.Windows.Forms.ColumnHeader[]
+            {
+                this.flaggeditemcolumn, this.flaggedreasoncolumn
+            });
+            this.flaggedlistview.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flaggedlistview.FullRowSelect = true;
+            this.flaggedlistview.HideSelection = false;
+            this.flaggedlistview.Location = new System.Drawing.Point(4, 24);
+            this.flaggedlistview.MultiSelect = false;
+            this.flaggedlistview.Name = "flaggedlistview";
+            this.flaggedlistview.Size = new System.Drawing.Size(1256, 122);
+            this.flaggedlistview.TabIndex = 0;
+            this.flaggedlistview.UseCompatibleStateImageBehavior = false;
+            this.flaggedlistview.View = System.Windows.Forms.View.Details;
+            this.flaggedlistview.MouseClick += new System.Windows.Forms.MouseEventHandler(this.flaggedlistview_MouseClick);
+            //
+            // flaggeditemcolumn
+            //
+            this.flaggeditemcolumn.Text = "Item";
+            this.flaggeditemcolumn.Width = 260;
+            //
+            // flaggedreasoncolumn
+            //
+            this.flaggedreasoncolumn.Text = "Reason";
+            this.flaggedreasoncolumn.Width = 500;
 
             //
             // imagelist
@@ -461,7 +540,7 @@ namespace Oxide.Patcher
             //
             this.categorymenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
             {
-                this.toolStripMenuItem1, this.toolStripMenuItem3, this.toolStripSeparator5, this.FlagCategory, this.UnflagCategory
+                this.toolStripMenuItem1, this.toolStripMenuItem3, this.toolStripSeparator5, this.FlagCategory, this.UnflagCategory, this.toolStripSeparator7, this.addNewHookToCategoryMenuItem
             });
             this.categorymenu.Name = "hooksmenu";
             this.categorymenu.Size = new System.Drawing.Size(127, 98);
@@ -505,11 +584,25 @@ namespace Oxide.Patcher
             this.UnflagCategory.Click += new System.EventHandler(this.UnflagCategory_Click);
 
             //
+            // toolStripSeparator7
+            //
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(123, 6);
+
+            //
+            // addNewHookToCategoryMenuItem
+            //
+            this.addNewHookToCategoryMenuItem.Name = "addNewHookToCategoryMenuItem";
+            this.addNewHookToCategoryMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.addNewHookToCategoryMenuItem.Text = "Add New Hook";
+            this.addNewHookToCategoryMenuItem.Click += new System.EventHandler(this.addnewhook_Click);
+
+            //
             // hookmenu
             //
             this.hookmenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
             {
-                this.toolStripMenuItem4, this.toolStripSeparator6, this.toolStripMenuItem5, this.toolStripMenuItem6
+                this.toolStripMenuItem4, this.toolStripSeparator6, this.toolStripMenuItem5, this.toolStripMenuItem6, this.toolStripSeparator8, this.addNewHookToRootMenuItem
             });
             this.hookmenu.Name = "hooksmenu";
             this.hookmenu.Size = new System.Drawing.Size(148, 76);
@@ -543,6 +636,20 @@ namespace Oxide.Patcher
             this.toolStripMenuItem6.Size = new System.Drawing.Size(147, 22);
             this.toolStripMenuItem6.Text = "Unflag All";
             this.toolStripMenuItem6.Click += new System.EventHandler(this.unflagall_Click);
+
+            //
+            // toolStripSeparator8
+            //
+            this.toolStripSeparator8.Name = "toolStripSeparator8";
+            this.toolStripSeparator8.Size = new System.Drawing.Size(144, 6);
+
+            //
+            // addNewHookToRootMenuItem
+            //
+            this.addNewHookToRootMenuItem.Name = "addNewHookToRootMenuItem";
+            this.addNewHookToRootMenuItem.Size = new System.Drawing.Size(147, 22);
+            this.addNewHookToRootMenuItem.Text = "Add New Hook";
+            this.addNewHookToRootMenuItem.Click += new System.EventHandler(this.addnewhook_Click);
 
             //
             // imagelistDragDrop
@@ -584,6 +691,7 @@ namespace Oxide.Patcher
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1264, 681);
             this.Controls.Add(this.splitter);
+            this.Controls.Add(this.flaggedpanel);
             this.Controls.Add(this.mainstatusbar);
             this.Controls.Add(this.maintoolbar);
             this.Controls.Add(this.mainmenu);
@@ -601,6 +709,7 @@ namespace Oxide.Patcher
             this.splitter.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitter)).EndInit();
             this.splitter.ResumeLayout(false);
+            this.flaggedpanel.ResumeLayout(false);
             this.tabviewcontextmenu.ResumeLayout(false);
             this.unloadedassemblymenu.ResumeLayout(false);
             this.loadedassemblymenu.ResumeLayout(false);
@@ -626,6 +735,11 @@ namespace Oxide.Patcher
         private System.Windows.Forms.StatusStrip mainstatusbar;
         private System.Windows.Forms.SplitContainer splitter;
         private System.Windows.Forms.TreeView objectview;
+        private System.Windows.Forms.Panel flaggedpanel;
+        private System.Windows.Forms.ListView flaggedlistview;
+        private System.Windows.Forms.ColumnHeader flaggeditemcolumn;
+        private System.Windows.Forms.ColumnHeader flaggedreasoncolumn;
+        private System.Windows.Forms.Label flaggedheaderlabel;
         private System.Windows.Forms.TabControl tabview;
         private System.Windows.Forms.ToolStripMenuItem newproject;
         private System.Windows.Forms.ToolStripMenuItem openproject;
@@ -643,6 +757,7 @@ namespace Oxide.Patcher
         private System.Windows.Forms.ContextMenuStrip loadedassemblymenu;
         private System.Windows.Forms.ToolStripMenuItem removefromproject;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
         private System.Windows.Forms.ToolStripButton patchtool;
         private System.Windows.Forms.ContextMenuStrip tabviewcontextmenu;
         private System.Windows.Forms.ToolStripMenuItem closeTabToolStripMenuItem;
@@ -658,6 +773,11 @@ namespace Oxide.Patcher
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem3;
         private System.Windows.Forms.ContextMenuStrip hookmenu;
+        private System.Windows.Forms.ToolStripButton showflaggedbutton;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+        private System.Windows.Forms.ToolStripMenuItem addNewHookToCategoryMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+        private System.Windows.Forms.ToolStripMenuItem addNewHookToRootMenuItem;
         public System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem5;

--- a/src/PatcherForm.cs
+++ b/src/PatcherForm.cs
@@ -52,6 +52,8 @@ namespace Oxide.Patcher
 
         private int newCategoryCount;
 
+        private bool _showOnlyFlagged;
+
         private TreeNode dragNode;
 
         private TreeNode tempDropNode;
@@ -491,6 +493,7 @@ namespace Oxide.Patcher
                     if (hook.Flagged)
                     {
                         hook.Flagged = false;
+                        hook.FlagReason = null;
                     }
                 }
 
@@ -507,6 +510,7 @@ namespace Oxide.Patcher
                     if (!hook.Flagged)
                     {
                         hook.Flagged = true;
+                        hook.FlagReason = "Manually flagged.";
                     }
                 }
 
@@ -524,6 +528,7 @@ namespace Oxide.Patcher
                     if (!hook.Flagged)
                     {
                         hook.Flagged = true;
+                        hook.FlagReason = "Manually flagged.";
                         UpdateHook(hook);
                     }
                 }
@@ -540,9 +545,38 @@ namespace Oxide.Patcher
                     if (hook.Flagged)
                     {
                         hook.Flagged = false;
+                        hook.FlagReason = null;
                         UpdateHook(hook);
                     }
                 }
+            }
+        }
+
+        private void addnewhook_Click(object sender, EventArgs e)
+        {
+            if (CurrentProject == null)
+            {
+                return;
+            }
+
+            if (CurrentProject.Manifests.Count == 0)
+            {
+                MessageBox.Show(this, "Add an assembly to the project before creating a hook.", "Oxide Patcher", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            TreeNode node = objectview.SelectedNode;
+            string categoryHint = node != null && (node.Tag as string) == "Category" ? node.Text : null;
+
+            using (HookDetailsForm form = new HookDetailsForm(CurrentProject, categoryHint))
+            {
+                if (form.ShowDialog(this) != DialogResult.OK)
+                {
+                    return;
+                }
+
+                AddHook(form.ResultHook);
+                GotoHook(form.ResultHook);
             }
         }
 
@@ -927,140 +961,313 @@ namespace Oxide.Patcher
 
         private async Task<TreeNode> GetHooks()
         {
-            return await Task.Run(() =>
+            return await Task.Run(() => BuildHooksTree(_showOnlyFlagged));
+        }
+
+        /// <summary>
+        /// Builds a fresh "Hooks" tree node from the current project data
+        /// </summary>
+        /// <param name="onlyFlagged">If true, unflagged hooks (and categories with no flagged hooks) are omitted</param>
+        private TreeNode BuildHooksTree(bool onlyFlagged)
+        {
+            TreeNode hooks = new TreeNode("Hooks")
             {
-                TreeNode hooks = new TreeNode("Hooks")
+                ImageKey = "lightning.png",
+                Name = "Hooks",
+                SelectedImageKey = "lightning.png",
+                Tag = "Hooks"
+            };
+
+            foreach (Hook hook in CurrentProject.Manifests.SelectMany(m => m.Hooks).OrderBy(h => h.Name))
+            {
+                if (onlyFlagged && !hook.Flagged)
                 {
-                    ImageKey = "lightning.png",
-                    Name = "Hooks",
-                    SelectedImageKey = "lightning.png",
-                    Tag = "Hooks"
-                };
+                    continue;
+                }
 
-                foreach (Hook hook in CurrentProject.Manifests.SelectMany(m => m.Hooks).OrderBy(h => h.Name))
+                TreeNode category = new TreeNode(hook.HookCategory);
+                if (hook.HookCategory != null)
                 {
-                    TreeNode category = new TreeNode(hook.HookCategory);
-                    if (hook.HookCategory != null)
+                    category.ImageKey = "folder.png";
+                    category.Name = hook.HookCategory;
+                    category.SelectedImageKey = "folder.png";
+                    category.Tag = "Category";
+                    if (!hooks.Nodes.ContainsKey(hook.HookCategory))
                     {
-                        category.ImageKey = "folder.png";
-                        category.Name = hook.HookCategory;
-                        category.SelectedImageKey = "folder.png";
-                        category.Tag = "Category";
-                        if (!hooks.Nodes.ContainsKey(hook.HookCategory))
-                        {
-                            hooks.Nodes.Add(category);
-                        }
-                        else
-                        {
-                            category = hooks.Nodes.Find(hook.HookCategory, true)[0];
-                        }
-                    }
-
-                    TreeNode hooknode = new TreeNode(hook.Name)
-                    {
-                        Name = hook.Name
-                    };
-
-                    if (hook.Flagged)
-                    {
-                        hooknode.ImageKey = "script_error.png";
-                        hooknode.SelectedImageKey = "script_error.png";
+                        hooks.Nodes.Add(category);
                     }
                     else
                     {
-                        hooknode.ImageKey = "script_lightning.png";
-                        hooknode.SelectedImageKey = "script_lightning.png";
-                    }
-
-                    hooknode.Tag = hook;
-
-                    if (hook.HookCategory == null)
-                    {
-                        hooks.Nodes.Add(hooknode);
-                    }
-                    else
-                    {
-                        category.Nodes.Add(hooknode);
-                        if (!hook.Flagged)
-                        {
-                            continue;
-                        }
-
-                        category.ImageKey = "folder_flagged.png";
-                        category.SelectedImageKey = "folder_flagged.png";
+                        category = hooks.Nodes.Find(hook.HookCategory, true)[0];
                     }
                 }
 
-                return hooks;
-            });
+                TreeNode hooknode = new TreeNode(hook.Name)
+                {
+                    Name = hook.Name,
+                    ForeColor = hook.Flagged ? Color.Red : Color.Empty
+                };
+
+                if (hook.Flagged)
+                {
+                    hooknode.ImageKey = "script_error.png";
+                    hooknode.SelectedImageKey = "script_error.png";
+                }
+                else
+                {
+                    hooknode.ImageKey = "script_lightning.png";
+                    hooknode.SelectedImageKey = "script_lightning.png";
+                }
+
+                hooknode.Tag = hook;
+
+                if (hook.HookCategory == null)
+                {
+                    hooks.Nodes.Add(hooknode);
+                }
+                else
+                {
+                    category.Nodes.Add(hooknode);
+                    if (!hook.Flagged)
+                    {
+                        continue;
+                    }
+
+                    category.ImageKey = "folder_flagged.png";
+                    category.SelectedImageKey = "folder_flagged.png";
+                }
+            }
+
+            return hooks;
+        }
+
+        /// <summary>
+        /// Rebuilds the "Hooks" tree node from scratch (respecting the flagged-only filter, if active)
+        /// and swaps it into the object view. Use this after changes that can't be applied with a
+        /// simple node update, such as moving a hook to a different category or changing its assembly.
+        /// </summary>
+        public void RefreshHooksTree()
+        {
+            RefreshFilteredTree("Hooks", BuildHooksTree);
+        }
+
+        /// <summary>
+        /// Rebuilds the "Modifiers" tree node from scratch (respecting the flagged-only filter, if active).
+        /// </summary>
+        public void RefreshModifiersTree()
+        {
+            RefreshFilteredTree("Modifiers", BuildModifiersTree);
+        }
+
+        /// <summary>
+        /// Rebuilds the "Fields" tree node from scratch (respecting the flagged-only filter, if active).
+        /// </summary>
+        public void RefreshFieldsTree()
+        {
+            RefreshFilteredTree("Fields", BuildFieldsTree);
+        }
+
+        private void RefreshFilteredTree(string nodeName, Func<bool, TreeNode> builder)
+        {
+            if (CurrentProject == null)
+            {
+                return;
+            }
+
+            TreeNode oldNode = objectview.Nodes[nodeName];
+            if (oldNode == null)
+            {
+                return;
+            }
+
+            int index = objectview.Nodes.IndexOf(oldNode);
+            bool wasExpanded = oldNode.IsExpanded;
+
+            TreeNode newNode = builder(_showOnlyFlagged);
+            Sort(newNode.Nodes, false);
+
+            objectview.Nodes.RemoveAt(index);
+            objectview.Nodes.Insert(index, newNode);
+
+            if (wasExpanded)
+            {
+                newNode.Expand();
+            }
+        }
+
+        private void showflaggedbutton_Click(object sender, EventArgs e)
+        {
+            if (CurrentProject == null)
+            {
+                return;
+            }
+
+            _showOnlyFlagged = !_showOnlyFlagged;
+            showflaggedbutton.Checked = _showOnlyFlagged;
+            RefreshHooksTree();
+            RefreshModifiersTree();
+            RefreshFieldsTree();
+        }
+
+        /// <summary>
+        /// Rebuilds the "Flagged Items" list at the bottom of the window from the current project
+        /// data, showing every currently flagged hook, modifier, and field along with the reason
+        /// it was flagged, if known.
+        /// </summary>
+        public void RefreshFlaggedList()
+        {
+            flaggedlistview.BeginUpdate();
+            flaggedlistview.Items.Clear();
+
+            if (CurrentProject != null)
+            {
+                foreach (Hook hook in CurrentProject.Manifests.SelectMany(m => m.Hooks).Where(h => h.Flagged).OrderBy(h => h.Name))
+                {
+                    ListViewItem item = new ListViewItem(new[] { hook.Name, hook.FlagReason ?? "MSIL Hash Changed" })
+                    {
+                        Tag = hook
+                    };
+                    flaggedlistview.Items.Add(item);
+                }
+
+                foreach (Modifier modifier in CurrentProject.Manifests.SelectMany(m => m.Modifiers).Where(m => m.Flagged).OrderBy(m => m.Name))
+                {
+                    ListViewItem item = new ListViewItem(new[] { modifier.Name, modifier.FlagReason ?? "MSIL Hash Changed" })
+                    {
+                        Tag = modifier
+                    };
+                    flaggedlistview.Items.Add(item);
+                }
+
+                foreach (Field field in CurrentProject.Manifests.SelectMany(m => m.Fields).Where(f => f.Flagged).OrderBy(f => f.Name))
+                {
+                    ListViewItem item = new ListViewItem(new[] { $"{field.TypeName}::{field.Name}", field.FlagReason ?? "MSIL Hash Changed" })
+                    {
+                        Tag = field
+                    };
+                    flaggedlistview.Items.Add(item);
+                }
+            }
+
+            flaggedlistview.EndUpdate();
+
+            flaggedheaderlabel.Text = flaggedlistview.Items.Count > 0
+                ? $"Flagged Items ({flaggedlistview.Items.Count})"
+                : "Flagged Items";
+        }
+
+        private void flaggedlistview_MouseClick(object sender, MouseEventArgs e)
+        {
+            ListViewItem item = flaggedlistview.GetItemAt(e.X, e.Y);
+            if (item == null)
+            {
+                return;
+            }
+
+            switch (item.Tag)
+            {
+                case Hook hook:
+                    GotoHook(hook);
+                    break;
+
+                case Modifier modifier:
+                    GotoModifier(modifier);
+                    break;
+
+                case Field field:
+                    GotoField(field);
+                    break;
+            }
         }
 
         private async Task<TreeNode> GetModifiers()
         {
-            return await Task.Run(() =>
+            return await Task.Run(() => BuildModifiersTree(_showOnlyFlagged));
+        }
+
+        private TreeNode BuildModifiersTree(bool onlyFlagged)
+        {
+            TreeNode modifiers = new TreeNode("Modifiers")
             {
-                TreeNode modifiers = new TreeNode("Modifiers")
-                {
-                    ImageKey = "lightning.png",
-                    Name = "Modifiers",
-                    SelectedImageKey = "lightning.png",
-                    Tag = "Modifiers"
-                };
+                ImageKey = "lightning.png",
+                Name = "Modifiers",
+                SelectedImageKey = "lightning.png",
+                Tag = "Modifiers"
+            };
 
-                foreach (Modifier modifier in CurrentProject.Manifests.SelectMany(m => m.Modifiers).OrderBy(m => m.Name))
+            foreach (Modifier modifier in CurrentProject.Manifests.SelectMany(m => m.Modifiers).OrderBy(m => m.Name))
+            {
+                if (onlyFlagged && !modifier.Flagged)
                 {
-                    TreeNode modifiernode = new TreeNode(modifier.Name);
-                    if (modifier.Flagged)
-                    {
-                        modifiernode.ImageKey = "script_error.png";
-                        modifiernode.SelectedImageKey = "script_error.png";
-                    }
-                    else
-                    {
-                        modifiernode.ImageKey = "script_lightning.png";
-                        modifiernode.SelectedImageKey = "script_lightning.png";
-                    }
-
-                    modifiernode.Tag = modifier;
-                    modifiers.Nodes.Add(modifiernode);
+                    continue;
                 }
 
-                return modifiers;
-            });
+                TreeNode modifiernode = new TreeNode(modifier.Name)
+                {
+                    ForeColor = modifier.Flagged ? Color.Red : Color.Empty
+                };
+
+                if (modifier.Flagged)
+                {
+                    modifiernode.ImageKey = "script_error.png";
+                    modifiernode.SelectedImageKey = "script_error.png";
+                }
+                else
+                {
+                    modifiernode.ImageKey = "script_lightning.png";
+                    modifiernode.SelectedImageKey = "script_lightning.png";
+                }
+
+                modifiernode.Tag = modifier;
+                modifiers.Nodes.Add(modifiernode);
+            }
+
+            return modifiers;
         }
 
         private async Task<TreeNode> GetFields()
         {
-            return await Task.Run(() =>
+            return await Task.Run(() => BuildFieldsTree(_showOnlyFlagged));
+        }
+
+        private TreeNode BuildFieldsTree(bool onlyFlagged)
+        {
+            TreeNode fields = new TreeNode("Fields")
             {
-                TreeNode fields = new TreeNode("Fields")
-                {
-                    ImageKey = "lightning.png",
-                    Name = "Fields",
-                    SelectedImageKey = "lightning.png",
-                    Tag = "Fields"
-                };
+                ImageKey = "lightning.png",
+                Name = "Fields",
+                SelectedImageKey = "lightning.png",
+                Tag = "Fields"
+            };
 
-                foreach (Field field in CurrentProject.Manifests.SelectMany(m => m.Fields).OrderBy(f => f.Name))
+            foreach (Field field in CurrentProject.Manifests.SelectMany(m => m.Fields).OrderBy(f => f.Name))
+            {
+                if (onlyFlagged && !field.Flagged)
                 {
-                    TreeNode fieldnode = new TreeNode($"{field.TypeName}::{field.Name}");
-                    if (field.Flagged)
-                    {
-                        fieldnode.ImageKey = "script_error.png";
-                        fieldnode.SelectedImageKey = "script_error.png";
-                    }
-                    else
-                    {
-                        fieldnode.ImageKey = "script_lightning.png";
-                        fieldnode.SelectedImageKey = "script_lightning.png";
-                    }
-
-                    fieldnode.Tag = field;
-                    fields.Nodes.Add(fieldnode);
+                    continue;
                 }
 
-                return fields;
-            });
+                TreeNode fieldnode = new TreeNode($"{field.TypeName}::{field.Name}")
+                {
+                    ForeColor = field.Flagged ? Color.Red : Color.Empty
+                };
+
+                if (field.Flagged)
+                {
+                    fieldnode.ImageKey = "script_error.png";
+                    fieldnode.SelectedImageKey = "script_error.png";
+                }
+                else
+                {
+                    fieldnode.ImageKey = "script_lightning.png";
+                    fieldnode.SelectedImageKey = "script_lightning.png";
+                }
+
+                fieldnode.Tag = field;
+                fields.Nodes.Add(fieldnode);
+            }
+
+            return fields;
         }
 
         private async Task GetAssemblies()
@@ -1511,6 +1718,7 @@ namespace Oxide.Patcher
 
             // Verify
             AssemblyLoader.VerifyProject();
+            RefreshFlaggedList();
 
             // Populate tree
             PopulateInitialTree();
@@ -1536,6 +1744,8 @@ namespace Oxide.Patcher
             // Set project to null
             CurrentProject = null;
             CurrentProjectFilename = null;
+
+            RefreshFlaggedList();
         }
 
         /// <summary>
@@ -1622,6 +1832,15 @@ namespace Oxide.Patcher
             Manifest manifest = CurrentProject.GetManifest(hook.AssemblyName);
             manifest.Hooks.Add(hook);
             CurrentProject.Save(CurrentProjectFilename);
+            RefreshFlaggedList();
+
+            if (_showOnlyFlagged && !hook.Flagged)
+            {
+                // The new hook wouldn't be visible under the current filter; just refresh
+                // so the tree stays consistent (it will appear once flagged or the filter is cleared)
+                RefreshHooksTree();
+                return;
+            }
 
             TreeNode hooks = null;
             foreach (object node in objectview.Nodes)
@@ -1640,7 +1859,8 @@ namespace Oxide.Patcher
 
             TreeNode hooknode = new TreeNode(hook.Name)
             {
-                Name = hook.Name
+                Name = hook.Name,
+                ForeColor = hook.Flagged ? Color.Red : Color.Empty
             };
 
             if (hook.Flagged)
@@ -1654,7 +1874,38 @@ namespace Oxide.Patcher
                 hooknode.SelectedImageKey = "script_lightning.png";
             }
             hooknode.Tag = hook;
-            hooks.Nodes.Add(hooknode);
+
+            if (string.IsNullOrEmpty(hook.HookCategory))
+            {
+                hooks.Nodes.Add(hooknode);
+            }
+            else
+            {
+                TreeNode category = hooks.Nodes[hook.HookCategory];
+                if (category == null)
+                {
+                    category = new TreeNode(hook.HookCategory)
+                    {
+                        Name = hook.HookCategory,
+                        ImageKey = "folder.png",
+                        SelectedImageKey = "folder.png",
+                        Tag = "Category"
+                    };
+                    hooks.Nodes.Add(category);
+                }
+
+                category.Nodes.Add(hooknode);
+
+                if (hook.Flagged)
+                {
+                    category.ImageKey = "folder_flagged.png";
+                    category.SelectedImageKey = "folder_flagged.png";
+                }
+
+                Sort(category.Nodes);
+            }
+
+            Sort(hooks.Nodes, false);
         }
 
         /// <summary>
@@ -1666,6 +1917,13 @@ namespace Oxide.Patcher
             Manifest manifest = CurrentProject.GetManifest(modifier.AssemblyName);
             manifest.Modifiers.Add(modifier);
             CurrentProject.Save(CurrentProjectFilename);
+            RefreshFlaggedList();
+
+            if (_showOnlyFlagged && !modifier.Flagged)
+            {
+                RefreshModifiersTree();
+                return;
+            }
 
             TreeNode modifiers = null;
             foreach (object node in objectview.Nodes)
@@ -1682,7 +1940,11 @@ namespace Oxide.Patcher
                 return;
             }
 
-            TreeNode modifiernode = new TreeNode(modifier.Name);
+            TreeNode modifiernode = new TreeNode(modifier.Name)
+            {
+                ForeColor = modifier.Flagged ? Color.Red : Color.Empty
+            };
+
             if (modifier.Flagged)
             {
                 modifiernode.ImageKey = "script_error.png";
@@ -1695,7 +1957,7 @@ namespace Oxide.Patcher
             }
             modifiernode.Tag = modifier;
             modifiers.Nodes.Add(modifiernode);
-            Sort(modifiernode.Nodes);
+            Sort(modifiers.Nodes);
         }
 
         /// <summary>
@@ -1707,6 +1969,13 @@ namespace Oxide.Patcher
             Manifest manifest = CurrentProject.GetManifest(field.AssemblyName);
             manifest.Fields.Add(field);
             CurrentProject.Save(CurrentProjectFilename);
+            RefreshFlaggedList();
+
+            if (_showOnlyFlagged && !field.Flagged)
+            {
+                RefreshFieldsTree();
+                return;
+            }
 
             TreeNode fields = null;
             foreach (object node in objectview.Nodes)
@@ -1723,7 +1992,11 @@ namespace Oxide.Patcher
                 return;
             }
 
-            TreeNode fieldnode = new TreeNode($"{field.TypeName}::{field.Name}");
+            TreeNode fieldnode = new TreeNode($"{field.TypeName}::{field.Name}")
+            {
+                ForeColor = field.Flagged ? Color.Red : Color.Empty
+            };
+
             if (field.Flagged)
             {
                 fieldnode.ImageKey = "script_error.png";
@@ -1736,7 +2009,7 @@ namespace Oxide.Patcher
             }
             fieldnode.Tag = field;
             fields.Nodes.Add(fieldnode);
-            Sort(fieldnode.Nodes);
+            Sort(fields.Nodes);
         }
 
         /// <summary>
@@ -1795,6 +2068,8 @@ namespace Oxide.Patcher
                     break;
                 }
             }
+
+            RefreshFlaggedList();
         }
 
         /// <summary>
@@ -1824,6 +2099,8 @@ namespace Oxide.Patcher
                     break;
                 }
             }
+
+            RefreshFlaggedList();
         }
 
         /// <summary>
@@ -1853,6 +2130,8 @@ namespace Oxide.Patcher
                     break;
                 }
             }
+
+            RefreshFlaggedList();
         }
 
         /// <summary>
@@ -1910,6 +2189,19 @@ namespace Oxide.Patcher
                 break;
             }
 
+            if (!batchUpdate)
+            {
+                RefreshFlaggedList();
+            }
+
+            //When only showing flagged hooks, a flag/unflag can add or remove a node entirely
+            //(and possibly a whole category), so just rebuild the tree rather than patch it in place
+            if (_showOnlyFlagged && !batchUpdate)
+            {
+                RefreshHooksTree();
+                return true;
+            }
+
             TreeNode hooks = objectview.Nodes["Hooks"];
             if (hooks == null)
             {
@@ -1923,6 +2215,7 @@ namespace Oxide.Patcher
 
                 node.ImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
                 node.SelectedImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
+                node.ForeColor = hook.Flagged ? Color.Red : Color.Empty;
 
                 if (node.Text != hook.Name)
                 {
@@ -1955,6 +2248,7 @@ namespace Oxide.Patcher
 
                 hookNode.ImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
                 hookNode.SelectedImageKey = hook.Flagged ? "script_error.png" : "script_lightning.png";
+                hookNode.ForeColor = hook.Flagged ? Color.Red : Color.Empty;
             }
 
             bool anyFlagged = false;
@@ -2004,6 +2298,15 @@ namespace Oxide.Patcher
             if (!batchUpdate)
             {
                 CurrentProject.Save(CurrentProjectFilename);
+                RefreshFlaggedList();
+            }
+
+            //When only showing flagged items, a flag/unflag can add or remove the node entirely,
+            //so just rebuild the tree rather than patch it in place
+            if (_showOnlyFlagged && !batchUpdate)
+            {
+                RefreshModifiersTree();
+                return;
             }
 
             TreeNode modifiers = objectview.Nodes["Modifiers"];
@@ -2021,6 +2324,7 @@ namespace Oxide.Patcher
 
                 treeNode.ImageKey = modifier.Flagged ? "script_error.png" : "script_lightning.png";
                 treeNode.SelectedImageKey = modifier.Flagged ? "script_error.png" : "script_lightning.png";
+                treeNode.ForeColor = modifier.Flagged ? Color.Red : Color.Empty;
 
                 if (treeNode.Text != modifier.Name)
                 {
@@ -2060,6 +2364,15 @@ namespace Oxide.Patcher
             if (!batchUpdate)
             {
                 CurrentProject.Save(CurrentProjectFilename);
+                RefreshFlaggedList();
+            }
+
+            //When only showing flagged items, a flag/unflag can add or remove the node entirely,
+            //so just rebuild the tree rather than patch it in place
+            if (_showOnlyFlagged && !batchUpdate)
+            {
+                RefreshFieldsTree();
+                return;
             }
 
             TreeNode fields = null;
@@ -2094,6 +2407,7 @@ namespace Oxide.Patcher
                         treenode.ImageKey = "script_lightning.png";
                         treenode.SelectedImageKey = "script_lightning.png";
                     }
+                    treenode.ForeColor = field.Flagged ? Color.Red : Color.Empty;
                     Sort(fields.Nodes);
                     break;
                 }
@@ -2110,6 +2424,12 @@ namespace Oxide.Patcher
                 }
 
                 CurrentProject.Save(CurrentProjectFilename);
+                RefreshFlaggedList();
+
+                if (_showOnlyFlagged)
+                {
+                    RefreshHooksTree();
+                }
             }
         }
 

--- a/src/Views/FieldViewControl.cs
+++ b/src/Views/FieldViewControl.cs
@@ -64,6 +64,7 @@ namespace Oxide.Patcher.Views
         private void flagbutton_Click(object sender, EventArgs e)
         {
             Field.Flagged = true;
+            Field.FlagReason = "Manually flagged.";
             MainForm.UpdateField(Field, false);
             flagbutton.Enabled = false;
             unflagbutton.Enabled = true;
@@ -72,6 +73,7 @@ namespace Oxide.Patcher.Views
         private void unflagbutton_Click(object sender, EventArgs e)
         {
             Field.Flagged = false;
+            Field.FlagReason = null;
             MainForm.UpdateField(Field, false);
             flagbutton.Enabled = true;
             unflagbutton.Enabled = false;

--- a/src/Views/HookViewControl.Designer.cs
+++ b/src/Views/HookViewControl.Designer.cs
@@ -44,6 +44,7 @@ namespace Oxide.Patcher.Views
             this.applybutton = new System.Windows.Forms.Button();
             this.deletebutton = new System.Windows.Forms.Button();
             this.clonebutton = new System.Windows.Forms.Button();
+            this.editdetailsbutton = new System.Windows.Forms.Button();
             this.namelabel = new System.Windows.Forms.Label();
             this.nametextbox = new System.Windows.Forms.TextBox();
             this.hooknamelabel = new System.Windows.Forms.Label();
@@ -205,6 +206,7 @@ namespace Oxide.Patcher.Views
             this.buttonholder.Controls.Add(this.applybutton);
             this.buttonholder.Controls.Add(this.deletebutton);
             this.buttonholder.Controls.Add(this.clonebutton);
+            this.buttonholder.Controls.Add(this.editdetailsbutton);
             this.buttonholder.Location = new System.Drawing.Point(3, 246);
             this.buttonholder.Name = "buttonholder";
             this.buttonholder.Size = new System.Drawing.Size(611, 30);
@@ -259,6 +261,16 @@ namespace Oxide.Patcher.Views
             this.clonebutton.Text = "Clone";
             this.clonebutton.UseVisualStyleBackColor = true;
             this.clonebutton.Click += new System.EventHandler(this.clonebutton_Click);
+            // 
+            // editdetailsbutton
+            // 
+            this.editdetailsbutton.Location = new System.Drawing.Point(408, 3);
+            this.editdetailsbutton.Name = "editdetailsbutton";
+            this.editdetailsbutton.Size = new System.Drawing.Size(97, 23);
+            this.editdetailsbutton.TabIndex = 11;
+            this.editdetailsbutton.Text = "Edit Details...";
+            this.editdetailsbutton.UseVisualStyleBackColor = true;
+            this.editdetailsbutton.Click += new System.EventHandler(this.editdetailsbutton_Click);
             // 
             // namelabel
             // 
@@ -454,5 +466,6 @@ namespace Oxide.Patcher.Views
         private System.Windows.Forms.TabPage codeaftertab;
         private System.Windows.Forms.TabPage codebeforetab;
         private System.Windows.Forms.Button clonebutton;
+        private System.Windows.Forms.Button editdetailsbutton;
     }
 }

--- a/src/Views/HookViewControl.cs
+++ b/src/Views/HookViewControl.cs
@@ -42,6 +42,8 @@ namespace Oxide.Patcher.Views
 
         private HighlightGroup _msilHighlight;
 
+        private HighlightGroup _codeHighlight;
+
         public HookViewControl()
         {
             InitializeComponent();
@@ -53,13 +55,7 @@ namespace Oxide.Patcher.Views
         {
             base.OnLoad(e);
 
-            _viewLoader = new AssemblyLoader(MainForm.CurrentProject, string.Empty, deferLoading: true);
-            _viewLoader.LoadAssembly(Hook.AssemblyName);
-            _methodDef = _viewLoader.GetMethod(Hook.AssemblyName, Hook.TypeName, Hook.Signature);
-
-            _viewLoaderAfter = new AssemblyLoader(MainForm.CurrentProject, string.Empty, deferLoading: true);
-            _viewLoaderAfter.LoadAssembly(Hook.AssemblyName);
-            _methodDefAfter = _viewLoaderAfter.GetMethod(Hook.AssemblyName, Hook.TypeName, Hook.Signature);
+            ResolveMethods();
 
             InitialiseDropdowns();
 
@@ -87,6 +83,43 @@ namespace Oxide.Patcher.Views
         }
 
         #region -Loading-
+
+        private void ResolveMethods()
+        {
+            _viewLoader = new AssemblyLoader(MainForm.CurrentProject, string.Empty, deferLoading: true);
+            _viewLoader.LoadAssembly(Hook.AssemblyName);
+            _methodDef = _viewLoader.GetMethod(Hook.AssemblyName, Hook.TypeName, Hook.Signature);
+
+            _viewLoaderAfter = new AssemblyLoader(MainForm.CurrentProject, string.Empty, deferLoading: true);
+            _viewLoaderAfter.LoadAssembly(Hook.AssemblyName);
+            _methodDefAfter = _viewLoaderAfter.GetMethod(Hook.AssemblyName, Hook.TypeName, Hook.Signature);
+        }
+
+        /// <summary>
+        /// Re-resolves the target method and rebuilds the MSIL/code before-after tabs.
+        /// Used after the hook's assembly, type, or signature is edited so the view
+        /// reflects the change immediately, without needing to reload the project.
+        /// </summary>
+        private async Task ReloadDetailsAsync()
+        {
+            ResolveMethods();
+
+            assemblytextbox.Text = Hook.AssemblyName;
+            typenametextbox.Text = Hook.TypeName;
+            methodnametextbox.Text = _methodDef != null ? Hook.Signature.ToString() : $"{Hook.Signature} (METHOD MISSING)";
+
+            _msilHighlight?.Dispose();
+            _codeHighlight?.Dispose();
+            _msilHighlight = null;
+            _codeHighlight = null;
+
+            beforetab.Controls.Clear();
+            aftertab.Controls.Clear();
+            codebeforetab.Controls.Clear();
+            codeaftertab.Controls.Clear();
+
+            await LoadCodeViews();
+        }
 
         private void InitialiseDropdowns()
         {
@@ -202,6 +235,11 @@ namespace Oxide.Patcher.Views
                 IsReadOnly = true
             };
             codeaftertab.Controls.Add(_codeAfter);
+            _codeHighlight = new HighlightGroup(_codeAfter);
+            if (patchApplied)
+            {
+                AddCodeHighlight(_codeAfter.Text);
+            }
         }
 
         private (string msilBefore, string msilAfter, bool patchApplied, Task<string> beforeTask, Task<string> afterTask) BuildBeforeAfter()
@@ -260,6 +298,37 @@ namespace Oxide.Patcher.Views
             _msilHighlight.AddMarker(marker);
         }
 
+        private void AddCodeHighlight(string codeAfterText)
+        {
+            int searchIndex = codeAfterText.IndexOf($"\"{Hook.HookName}\"");
+            if (searchIndex == -1)
+            {
+                return;
+            }
+
+            int lineStart = codeAfterText.LastIndexOf('\n', searchIndex) + 1;
+            int lineEnd = codeAfterText.IndexOf('\n', searchIndex);
+            if (lineEnd == -1)
+            {
+                lineEnd = codeAfterText.Length;
+            }
+
+            int length = lineEnd - lineStart;
+            if (length > 0 && codeAfterText[lineStart + length - 1] == '\r')
+            {
+                length--;
+            }
+
+            if (length <= 0)
+            {
+                return;
+            }
+
+            TextMarker marker = new TextMarker(lineStart, length, TextMarkerType.SolidBlock, Color.Yellow, Color.Black);
+
+            _codeHighlight.AddMarker(marker);
+        }
+
         #endregion
 
         #region -Actions-
@@ -281,6 +350,7 @@ namespace Oxide.Patcher.Views
         private void flagbutton_Click(object sender, EventArgs e)
         {
             Hook.Flagged = true;
+            Hook.FlagReason = "Manually flagged.";
             MainForm.UpdateHook(Hook);
             flagbutton.Enabled = false;
             unflagbutton.Enabled = true;
@@ -289,6 +359,7 @@ namespace Oxide.Patcher.Views
         private void unflagbutton_Click(object sender, EventArgs e)
         {
             Hook.Flagged = false;
+            Hook.FlagReason = null;
             MainForm.UpdateHook(Hook);
             if (Hook.Flagged)
             {
@@ -297,6 +368,46 @@ namespace Oxide.Patcher.Views
 
             flagbutton.Enabled = true;
             unflagbutton.Enabled = false;
+        }
+
+        private async void editdetailsbutton_Click(object sender, EventArgs e)
+        {
+            Hook resultHook;
+
+            using (HookDetailsForm form = new HookDetailsForm(MainForm.CurrentProject, Hook))
+            {
+                if (form.ShowDialog(MainForm) != DialogResult.OK)
+                {
+                    return;
+                }
+
+                resultHook = form.ResultHook;
+            }
+
+            if (resultHook != Hook)
+            {
+                // The hook type was changed, which requires the underlying object to be
+                // recreated - swap it in. This also removes the tab this control is hosted in.
+                MainForm.RemoveHook(Hook);
+                MainForm.AddHook(resultHook);
+                MainForm.GotoHook(resultHook);
+                return;
+            }
+
+            MainForm.CurrentProject.Save(MainForm.CurrentProjectFilename);
+            MainForm.RefreshHooksTree();
+
+            if (Parent is TabPage tabPage)
+            {
+                tabPage.Text = Hook.Name;
+            }
+
+            nametextbox.Text = Hook.Name;
+            hooknametextbox.Text = Hook.HookName;
+            hookdescriptiontextbox.Text = Hook.HookDescription;
+            applybutton.Enabled = false;
+
+            await ReloadDetailsAsync();
         }
 
         private void hooktypedropdown_SelectedIndexChanged(object sender, EventArgs e)
@@ -371,6 +482,7 @@ namespace Oxide.Patcher.Views
 
                 _msilBefore.Text = msilBefore;
                 _msilAfter.Text = msilAfter;
+                _msilHighlight.Clear();
                 if (patchApplied)
                 {
                     AddHighlight(msilAfter);
@@ -378,6 +490,11 @@ namespace Oxide.Patcher.Views
 
                 _codeBefore.Text = await beforeTask;
                 _codeAfter.Text = await afterTask;
+                _codeHighlight.Clear();
+                if (patchApplied)
+                {
+                    AddCodeHighlight(_codeAfter.Text);
+                }
             }
 
             applybutton.Enabled = false;

--- a/src/Views/ModifierViewControl.cs
+++ b/src/Views/ModifierViewControl.cs
@@ -102,6 +102,7 @@ namespace Oxide.Patcher.Views
         private void flagbutton_Click(object sender, EventArgs e)
         {
             Modifier.Flagged = true;
+            Modifier.FlagReason = "Manually flagged.";
             MainForm.UpdateModifier(Modifier, false);
             flagbutton.Enabled = false;
             unflagbutton.Enabled = true;
@@ -110,6 +111,7 @@ namespace Oxide.Patcher.Views
         private void unflagbutton_Click(object sender, EventArgs e)
         {
             Modifier.Flagged = false;
+            Modifier.FlagReason = null;
             MainForm.UpdateModifier(Modifier, false);
             flagbutton.Enabled = true;
             unflagbutton.Enabled = false;


### PR DESCRIPTION
Add "Flagged" Button to tool bar.
It will hide all non-flagged hooks, modifiers and fields from the list view.
Flagged hooks, modifiers and fields now have red text.

Add List view panel to bottom.
It lists all flagged hooks, modifiers and fields with there reason.
Double clicking will take you straight to that hooks page.

Right clicking on a category in the list view will now let you create a hook.
Add Create new hook page which exposes all the settings required to make a new hook without having to hand edit and reload.

Add Edit details button to hooks page. Allows you to fully edit the hooks settings without having to hand edit opj.

Add Find method button to add hook and edit hook details page.
It lists all types, methods, fields, properties like dnspy would. You can also search by partial name to allow finding missing hooks easily.

<img width="1923" height="1541" alt="image" src="https://github.com/user-attachments/assets/640a595b-aaf5-4d22-906f-11729327959f" />

<img width="2136" height="1568" alt="image" src="https://github.com/user-attachments/assets/5be91bfe-21ef-4ca2-b129-d2cb1e06c599" />
